### PR TITLE
Import latest data from geonames.org

### DIFF
--- a/src/data/admin1Codes.txt
+++ b/src/data/admin1Codes.txt
@@ -5,45 +5,45 @@ AD.03	Encamp	Encamp	3040684
 AD.02	Canillo	Canillo	3041203
 AD.07	Andorra la Vella	Andorra la Vella	3041566
 AD.08	Escaldes-Engordany	Escaldes-Engordany	3338529
-AE.07	Umm al Qaywayn	Umm al Qaywayn	290595
-AE.05	Raʼs al Khaymah	Ra's al Khaymah	291075
+AE.07	Imārat Umm al Qaywayn	Imarat Umm al Qaywayn	290595
+AE.05	Raʼs al Khaymah	Imarat Ra's al Khaymah	291075
 AE.03	Dubai	Dubai	292224
-AE.06	Ash Shāriqah	Ash Shariqah	292673
-AE.04	Al Fujayrah	Al Fujayrah	292879
+AE.06	Sharjah	Sharjah	292673
+AE.04	Fujairah	Fujairah	292879
 AE.02	Ajman	Ajman	292933
 AE.01	Abu Dhabi	Abu Dhabi	292969
 AF.28	Zabul	Zabul	1121143
-AF.27	Vardak	Vardak	1121863
-AF.26	Takhār	Takhar	1123230
-AF.33	Sar-e Pol	Sar-e Pol	1127106
-AF.32	Samangān	Samangan	1127766
-AF.40	Parvān	Parvan	1131054
-AF.29	Paktīkā	Paktika	1131256
+AF.27	Maidan Wardak Province	Maidan Wardak Province	1121863
+AF.26	Takhar	Takhar	1123230
+AF.33	Sar-e Pol Province	Sar-e Pol Province	1127106
+AF.32	Samangan	Samangan	1127766
+AF.40	Parwan	Parwan	1131054
+AF.29	Paktika	Paktika	1131256
 AF.36	Paktia	Paktia	1131257
-AF.39	Orūzgān	Oruzgan	1131461
-AF.19	Nīmrūz	Nimruz	1131821
-AF.18	Nangarhār	Nangarhar	1132366
-AF.17	Lowgar	Lowgar	1134561
-AF.35	Laghmān	Laghman	1135022
+AF.39	Oruzgan	Oruzgan	1131461
+AF.19	Nimroz	Nimroz	1131821
+AF.18	Nangarhar	Nangarhar	1132366
+AF.17	Logar	Logar	1134561
+AF.35	Laghman	Laghman	1135022
 AF.24	Kunduz	Kunduz	1135690
-AF.34	Konar	Konar	1135702
-AF.14	Kāpīsā	Kapisa	1138255
-AF.23	Kandahār	Kandahar	1138335
+AF.34	Kunar	Kunar	1135702
+AF.14	Kapisa	Kapisa	1138255
+AF.23	Kandahar	Kandahar	1138335
 AF.13	Kabul	Kabul	1138957
-AF.31	Jowzjān	Jowzjan	1139049
+AF.31	Jowzjan	Jowzjan	1139049
 AF.11	Herat	Herat	1140025
 AF.10	Helmand	Helmand	1140043
 AF.09	Ghowr	Ghowr	1141103
-AF.08	Ghaznī	Ghazni	1141268
+AF.08	Ghazni	Ghazni	1141268
 AF.07	Faryab	Faryab	1142226
 AF.06	Farah	Farah	1142263
-AF.05	Bāmīān	Bamian	1147239
+AF.05	Bamyan	Bamyan	1147239
 AF.30	Balkh	Balkh	1147288
-AF.03	Wilāyat-e Baghlān	Wilayat-e Baghlan	1147537
+AF.03	Baghlan	Baghlan	1147537
 AF.02	Badghis	Badghis	1147707
 AF.01	Badakhshan	Badakhshan	1147745
 AF.37	Khowst	Khowst	1444362
-AF.38	Nūrestān	Nurestan	1444363
+AF.38	Nuristan	Nuristan	1444363
 AF.41	Daykundi	Daykundi	6957553
 AF.42	Panjshir	Panjshir	6957555
 AG.08	Saint Philip	Saint Philip	3576015
@@ -54,33 +54,47 @@ AG.04	Saint John	Saint John	3576023
 AG.03	Saint George	Saint George	3576024
 AG.09	Redonda	Redonda	3576037
 AG.01	Barbuda	Barbuda	3576390
-AL.40	Berat	Berat	865730
-AL.41	Dibër	Diber	865731
-AL.43	Elbasan	Elbasan	865732
-AL.45	Gjirokastër	Gjirokaster	865733
-AL.46	Korçë	Korce	865734
-AL.47	Kukës	Kukes	865735
-AL.42	Durrës	Durres	3344947
-AL.44	Fier	Fier	3344948
-AL.48	Lezhë	Lezhe	3344949
-AL.49	Shkodër	Shkoder	3344950
-AL.50	Tiranë	Tirane	3344951
-AL.51	Vlorë	Vlore	3344952
+AI.11205389	Blowing Point	Blowing Point	11205389
+AI.11205392	Sandy Ground	Sandy Ground	11205392
+AI.11205393	Sandy Hill	Sandy Hill	11205393
+AI.11205396	The Valley	The Valley	11205396
+AI.11205433	East End	East End	11205433
+AI.11205436	North Hill	North Hill	11205436
+AI.11205437	West End	West End	11205437
+AI.11205438	South Hill	South Hill	11205438
+AI.11205439	The Quarter	The Quarter	11205439
+AI.11205440	North Side	North Side	11205440
+AI.11205441	Island Harbour	Island Harbour	11205441
+AI.11205442	George Hill	George Hill	11205442
+AI.11205443	Stoney Ground	Stoney Ground	11205443
+AI.11205444	The Farrington	The Farrington	11205444
+AL.40	Berat County	Berat County	865730
+AL.41	Dibër County	Diber County	865731
+AL.43	Elbasan County	Elbasan County	865732
+AL.45	Gjirokastër County	Gjirokaster County	865733
+AL.46	Korçë County	Korce County	865734
+AL.47	Kukës County	Kukes County	865735
+AL.42	Durrës County	Durres County	3344947
+AL.44	Fier County	Fier County	3344948
+AL.48	Lezhë County	Lezhe County	3344949
+AL.49	Shkodër County	Shkoder County	3344950
+AL.50	Tirana	Tirana	3344951
+AL.51	Vlorë County	Vlore County	3344952
 AM.02	Ararat	Ararat	409313
-AM.08	Syunikʼ	Syunik'i Marz	409314
-AM.10	Vayotsʼ Dzor	Vayots' Dzori Marz	409315
+AM.08	Syunik	Syunik	409314
+AM.10	Vayots Dzor	Vayots Dzor	409315
 AM.11	Yerevan	Yerevan	616051
 AM.01	Aragatsotn	Aragatsotn	828259
 AM.03	Armavir	Armavir	828260
-AM.04	Gegharkʼunikʼ	Geghark'unik'i Marz	828261
-AM.05	Kotaykʼ	Kotayk'i Marz	828262
-AM.06	Lorri	Lorri	828263
+AM.04	Gegharkunik	Gegharkunik	828261
+AM.05	Kotayk	Kotayk	828262
+AM.06	Lori	Lori	828263
 AM.07	Shirak	Shirak	828264
 AM.09	Tavush	Tavush	828265
 AO.18	Lunda Sul	Lunda Sul	145701
-AO.17	Lunda Norte	Lunda Norte	145702
+AO.17	Luanda Norte	Luanda Norte	145702
 AO.14	Moxico	Moxico	875996
-AO.04	Cuando Cubango	Cuando Cubango	876337
+AO.04	Cuando Cobango	Cuando Cobango	876337
 AO.16	Zaire	Zaire	2236355
 AO.15	Uíge	Uige	2236566
 AO.12	Malanje	Malanje	2239858
@@ -92,8 +106,8 @@ AO.13	Namibe	Namibe	3347016
 AO.09	Huíla	Huila	3348303
 AO.08	Huambo	Huambo	3348310
 AO.07	Cunene	Cunene	3349096
-AO.06	Cuanza Sul	Cuanza Sul	3349234
-AO.02	Bié	Bie	3351640
+AO.06	Kwanza Sul	Kwanza Sul	3349234
+AO.02	Bíe	Bie	3351640
 AO.01	Benguela	Benguela	3351660
 AR.14	Misiones	Misiones	3430657
 AR.09	Formosa	Formosa	3433896
@@ -101,7 +115,7 @@ AR.07	Buenos Aires F.D.	Buenos Aires F.D.	3433955
 AR.08	Entre Rios	Entre Rios	3434137
 AR.06	Corrientes	Corrientes	3435214
 AR.01	Buenos Aires	Buenos Aires	3435907
-AR.24	Tucumán	Tucuman	3833578
+AR.24	Tucuman	Tucuman	3833578
 AR.23	Tierra del Fuego	Tierra del Fuego	3834450
 AR.22	Santiago del Estero	Santiago del Estero	3835868
 AR.21	Santa Fe	Santa Fe	3836276
@@ -147,7 +161,7 @@ AX.213	Ålands skärgård	Alands skaergard	9611694
 AZ.12	Beyləqan	Beylaqan	146879
 AZ.69	Zǝngilan	Zangilan Rayon	146900
 AZ.66	Yardımlı	Yardimli	146962
-AZ.55	Şuşa	Susa	147163
+AZ.55	Shusha	Shusha	147163
 AZ.49	Salyan	Salyan	147269
 AZ.46	Sabirabad	Sabirabad	147284
 AZ.45	Saatlı	Saatli	147287
@@ -161,7 +175,7 @@ AZ.28	Laçın	Lacin	147626
 AZ.43	Qubadlı	Qubadli	147694
 AZ.24	İmişli	Imisli	147983
 AZ.18	Füzuli	Fuezuli	148107
-AZ.14	Cǝbrayıl	Cabrayil Rayonu	148140
+AZ.14	Jabrayil	Jabrayil	148140
 AZ.15	Jalilabad	Jalilabad	148155
 AZ.08	Astara	Astara	148442
 AZ.64	Xocalı	Xocali	148449
@@ -169,10 +183,10 @@ AZ.02	Ağcabǝdi	Aghjabadi Rayon	148615
 AZ.03	Ağdam	Agdam	148617
 AZ.07	Shirvan	Shirvan	409417
 AZ.30	Lankaran Sahari	Lankaran Sahari	409418
-AZ.56	Şuşa Şəhəri	Shusha	409419
+AZ.56	Shusha City	Shusha City	409419
 AZ.57	Tǝrtǝr	Tartar Rayon	409420
 AZ.61	Xankǝndi	Xankandi Sahari	409421
-AZ.65	Xocavǝnd	Xocavand Rayonu	409423
+AZ.65	Khojavend	Khojavend	409423
 AZ.71	Zərdab	Zardab	584583
 AZ.70	Zaqatala	Zaqatala	584604
 AZ.67	Yevlax	Yevlax	584650
@@ -180,7 +194,7 @@ AZ.37	Oğuz	Oguz	584742
 AZ.59	Ucar	Ucar	584783
 AZ.58	Tovuz	Tovuz	584861
 AZ.50	Şamaxı	Samaxi	585030
-AZ.47	Şǝki	Shaki Rayon	585031
+AZ.47	Shaki	Shaki	585031
 AZ.51	Şǝmkir	Shamkir Rayon	585059
 AZ.27	Kürdǝmir	Kurdamir Rayon	585686
 AZ.38	Qǝbǝlǝ	Qabala Rayon	585738
@@ -188,16 +202,16 @@ AZ.44	Qusar	Qusar	585749
 AZ.42	Quba	Quba	585786
 AZ.62	Goygol Rayon	Goygol Rayon	585967
 AZ.60	Xaçmaz	Xacmaz	586001
-AZ.26	Kǝlbǝcǝr	Kalbacar Rayonu	586047
+AZ.26	Kalbajar	Kalbajar	586047
 AZ.40	Qazax	Qazax	586087
 AZ.21	Goranboy	Goranboy	586112
-AZ.39	Qǝx	Qakh Rayon	586290
+AZ.39	Qax	Qax	586290
 AZ.25	İsmayıllı	Ismayilli	586320
 AZ.22	Göyçay	Goeycay	586482
 AZ.17	Shabran	Shabran	586725
 AZ.16	Daşkǝsǝn	Dashkasan Rayon	586771
 AZ.10	Balakǝn	Balakan Rayon	587010
-AZ.11	Bǝrdǝ	Barda Rayon	587056
+AZ.11	Barda	Barda	587056
 AZ.09	Baki	Baki	587081
 AZ.01	Abşeron	Abseron	587245
 AZ.06	Ağsu	Agsu	587342
@@ -215,9 +229,8 @@ AZ.54	Sumqayit	Sumqayit	828305
 AZ.63	Xızı	Xizi	828306
 AZ.68	Yevlax City	Yevlax City	828307
 AZ.23	Hacıqabul	Haciqabul	828315
-AZ.75	Nakhchivan	Nakhchivan	8411069
-BA.01	Federation of Bosnia and Herzegovina	Federation of Bosnia and Herzegovina	3229999
-BA.02	Republika Srpska	Republika Srpska	3230000
+BA.01	Federation of B&H	Federation of B&H	3229999
+BA.02	Srpska	Srpska	3230000
 BA.BRC	Brčko	Brcko	3294903
 BB.11	Saint Thomas	Saint Thomas	3373551
 BB.10	Saint Philip	Saint Philip	3373553
@@ -230,13 +243,14 @@ BB.04	Saint James	Saint James	3373570
 BB.03	Saint George	Saint George	3373572
 BB.02	Saint Andrew	Saint Andrew	3373580
 BB.01	Christ Church	Christ Church	3373988
-BD.83	Rājshāhi	Rajshahi	1337166
+BD.83	Rajshahi Division	Rajshahi Division	1337166
 BD.81	Dhaka	Dhaka	1337179
 BD.84	Chittagong	Chittagong	1337200
 BD.82	Khulna	Khulna	1337210
 BD.85	Barisāl	Barisal	1337229
 BD.86	Sylhet	Sylhet	1477362
 BD.87	Rangpur Division	Rangpur Division	7671048
+BD.H	Mymensingh Division	Mymensingh Division	11287936
 BE.BRU	Brussels Capital	Brussels Capital	2800867
 BE.WAL	Wallonia	Wallonia	3337387
 BE.VLG	Flanders	Flanders	3337388
@@ -248,43 +262,42 @@ BF.05	Centre-Nord	Centre-Nord	6930706
 BF.06	Centre-Ouest	Centre-Ouest	6930707
 BF.07	Centre-Sud	Centre-Sud	6930708
 BF.08	Est	Est	6930709
-BF.09	High-Basins	High-Basins	6930710
+BF.09	Hauts-Bassins	Hauts-Bassins	6930710
 BF.10	Nord	Nord	6930711
 BF.11	Plateau-Central	Plateau-Central	6930712
 BF.12	Sahel	Sahel	6930713
-BF.13	Southwest	Southwest	6930714
+BF.13	Sud-Ouest	Sud-Ouest	6930714
 BG.52	Razgrad	Razgrad	453751
 BG.47	Montana	Montana	453753
 BG.64	Vratsa	Vratsa	725713
 BG.61	Varna	Varna	726051
 BG.40	Dobrich	Dobrich	726419
-BG.58	Sofiya	Sofiya	727012
+BG.58	Sofia	Sofia	727012
 BG.53	Ruse	Ruse	727524
 BG.51	Plovdiv	Plovdiv	728194
 BG.50	Pleven	Pleven	728204
 BG.49	Pernik	Pernik	728331
 BG.48	Pazardzhik	Pazardzhik	728379
 BG.46	Lovech	Lovech	729560
-BG.43	Khaskovo	Khaskovo	730436
+BG.43	Haskovo	Haskovo	730436
 BG.42	Sofia-Capital	Sofia-Capital	731061
 BG.39	Burgas	Burgas	732771
 BG.38	Blagoevgrad	Blagoevgrad	733192
 BG.41	Gabrovo	Gabrovo	864552
-BG.44	Kŭrdzhali	Kurdzhali	864553
+BG.44	Kardzhali	Kardzhali	864553
 BG.45	Kyustendil	Kyustendil	864554
 BG.54	Shumen	Shumen	864555
 BG.55	Silistra	Silistra	864556
 BG.56	Sliven	Sliven	864557
 BG.57	Smolyan	Smolyan	864558
 BG.59	Stara Zagora	Stara Zagora	864559
-BG.60	Tŭrgovishte	Turgovishte	864560
-BG.62	Veliko Tŭrnovo	Veliko Turnovo	864561
+BG.60	Targovishte	Targovishte	864560
+BG.62	Veliko Tarnovo	Veliko Tarnovo	864561
 BG.63	Vidin	Vidin	864562
 BG.65	Yambol	Yambol	864563
 BH.15	Muharraq	Muharraq	290333
 BH.16	Manama	Manama	7090954
 BH.17	Southern Governorate	Southern Governorate	7090972
-BH.18	Central Governorate	Central Governorate	7090973
 BH.19	Northern	Northern	7090974
 BI.17	Makamba	Makamba	422233
 BI.10	Bururi	Bururi	423327
@@ -303,8 +316,9 @@ BI.20	Rutana	Rutana	434147
 BI.23	Mwaro	Mwaro	434386
 BI.24	Bujumbura Mairie	Bujumbura Mairie	7303939
 BI.25	Bujumbura Rural	Bujumbura Rural	7303940
+BI.26	Rumonge	Rumonge	11184798
 BJ.18	Zou	Zou	2390719
-BJ.16	Quémé	Queme	2392325
+BJ.16	Ouémé	Oueme	2392325
 BJ.15	Mono	Mono	2392716
 BJ.10	Borgou	Borgou	2394992
 BJ.09	Atlantique	Atlantique	2395504
@@ -323,29 +337,29 @@ BM.07	Saint Georgeʼs	Saint George's Parish	3573057
 BM.06	Saint George	Saint George	3573062
 BM.05	Pembroke	Pembroke	3573095
 BM.04	Paget	Paget	3573103
-BM.02	Hamilton Parish	Hamilton Parish	3573195
+BM.02	Hamilton	Hamilton	3573195
 BM.03	Hamilton city	Hamilton city	3573198
 BM.01	Devonshire	Devonshire	3573251
 BN.04	Tutong	Tutong	1820068
 BN.03	Temburong	Temburong	1820106
-BN.02	Brunei and Muara	Brunei and Muara	1820818
+BN.02	Brunei-Muara District	Brunei-Muara District	1820818
 BN.01	Belait	Belait	1820869
-BO.09	Tarija	Tarija	3903319
-BO.08	Santa Cruz	Santa Cruz	3904907
-BO.07	Potosí	Potosi	3907580
+BO.09	Tarija Department	Tarija Department	3903319
+BO.08	Santa Cruz Department	Santa Cruz Department	3904907
+BO.07	Potosí Department	Potosi Department	3907580
 BO.06	Pando	Pando	3908600
 BO.05	Oruro	Oruro	3909233
-BO.04	La Paz	La Paz	3911924
+BO.04	La Paz Department	La Paz Department	3911924
 BO.02	Cochabamba	Cochabamba	3919966
-BO.01	Chuquisaca	Chuquisaca	3920177
-BO.03	El Beni	El Beni	3923172
+BO.01	Chuquisaca Department	Chuquisaca Department	3920177
+BO.03	Beni Department	Beni Department	3923172
 BQ.BO	Bonaire	Bonaire	7609816
 BQ.SB	Saba	Saba	7610358
 BQ.SE	Sint Eustatius	Sint Eustatius	7610359
 BR.22	Rio Grande do Norte	Rio Grande do Norte	3390290
 BR.20	Piauí	Piaui	3392213
 BR.30	Pernambuco	Pernambuco	3392268
-BR.17	Paraiba	Paraiba	3393098
+BR.17	Paraíba	Paraiba	3393098
 BR.16	Pará	Para	3393129
 BR.13	Maranhão	Maranhao	3395443
 BR.06	Ceará	Ceara	3402362
@@ -401,45 +415,52 @@ BS.51	South Andros	South Andros	8030556
 BS.52	South Eleuthera	South Eleuthera	8030557
 BS.53	Spanish Wells	Spanish Wells	8030558
 BS.54	West Grand Bahama	West Grand Bahama	8030559
-BT.05	Bumthang	Bumthang	1337278
-BT.06	Chhukha	Chhukha	1337279
-BT.08	Daga	Daga	1337280
-BT.07	Chirang	Chirang	1337281
-BT.09	Geylegphug	Geylegphug	1337282
-BT.10	Ha	Ha	1337283
-BT.11	Lhuntshi	Lhuntshi	1337284
+BT.05	Bumthang District	Bumthang District	1337278
+BT.06	Chukha	Chukha	1337279
+BT.08	Dagana	Dagana	1337280
+BT.07	Tsirang District	Tsirang District	1337281
+BT.09	Sarpang District	Sarpang District	1337282
+BT.10	Haa	Haa	1337283
+BT.11	Lhuntse	Lhuntse	1337284
 BT.12	Mongar	Mongar	1337285
 BT.13	Paro	Paro	1337286
-BT.14	Pemagatsel	Pemagatsel	1337287
+BT.14	Pemagatshel	Pemagatshel	1337287
 BT.15	Punakha	Punakha	1337288
-BT.16	Samchi	Samchi	1337289
+BT.16	Samtse District	Samtse District	1337289
 BT.17	Samdrup Jongkhar	Samdrup Jongkhar	1337290
-BT.18	Shemgang	Shemgang	1337291
-BT.19	Tashigang	Tashigang	1337292
-BT.20	Thimphu	Thimphu	1337293
+BT.18	Zhemgang District	Zhemgang District	1337291
+BT.19	Trashigang District	Trashigang District	1337292
+BT.20	Thimphu District	Thimphu District	1337293
 BT.21	Tongsa	Tongsa	1337294
 BT.22	Wangdi Phodrang	Wangdi Phodrang	1337295
 BT.23	Gasa	Gasa	7303651
 BT.24	Trashi Yangste	Trashi Yangste	7303653
-BW.10	Southern	Southern	933043
-BW.09	South East	South East	933044
-BW.08	North East	North East	933210
-BW.11	North West	North West	933230
+BW.10	Ngwaketsi	Ngwaketsi	933043
+BW.09	South-East	South-East	933044
+BW.08	North-East	North-East	933210
+BW.11	North-West	North-West	933230
 BW.06	Kweneng	Kweneng	933562
 BW.05	Kgatleng	Kgatleng	933654
 BW.04	Kgalagadi	Kgalagadi	933657
 BW.03	Ghanzi	Ghanzi	933758
+BW.12	Chobe	Chobe	933840
 BW.01	Central	Central	933851
+BW.13	City of Francistown	City of Francistown	11778168
+BW.14	Gaborone	Gaborone	11778169
+BW.15	Jwaneng	Jwaneng	11778170
+BW.16	Lobatse	Lobatse	11778171
+BW.17	Selibe Phikwe	Selibe Phikwe	11778172
+BW.18	Sowa Town	Sowa Town	11778173
 BY.07	Vitebsk	Vitebsk	620134
 BY.06	Mogilev	Mogilev	625073
 BY.05	Minsk	Minsk	625142
-BY.04	Minsk	Minsk	625143
+BY.04	Minsk City	Minsk City	625143
 BY.03	Grodnenskaya	Grodnenskaya	628035
-BY.02	Gomel	Gomel	628281
+BY.02	Gomel Oblast	Gomel Oblast	628281
 BY.01	Brest	Brest	629631
 BZ.06	Toledo	Toledo	3580913
-BZ.05	Stann Creek	Stann Creek	3580975
-BZ.04	Orange Walk	Orange Walk	3581511
+BZ.05	Southern District	Southern District	3580975
+BZ.04	Orange Walk District	Orange Walk District	3581511
 BZ.03	Corozal	Corozal	3582302
 BZ.02	Cayo	Cayo	3582429
 BZ.01	Belize	Belize	3582676
@@ -456,17 +477,32 @@ CA.10	Quebec	Quebec	6115047
 CA.11	Saskatchewan	Saskatchewan	6141242
 CA.12	Yukon	Yukon	6185811
 CA.05	Newfoundland and Labrador	Newfoundland and Labrador	6354959
+CD.31	Tshuapa	Tshuapa	204697
+CD.30	Tshopo	Tshopo	204704
+CD.29	Tanganyika	Tanganyika	205253
 CD.12	South Kivu	South Kivu	205413
-CD.05	Katanga	Katanga	205703
+CD.27	Sankuru	Sankuru	205828
 CD.11	Nord Kivu	Nord Kivu	206938
+CD.25	Mongala	Mongala	208741
 CD.10	Maniema	Maniema	209610
+CD.23	Kasai-Central	Kasai-Central	210596
 CD.04	Kasaï-Oriental	Kasai-Oriental	214138
-CD.03	Kasaï-Occidental	Kasai-Occidental	214139
-CD.09	Eastern Province	Eastern Province	216139
+CD.18	Kasai	Kasai	214140
+CD.17	Ituri	Ituri	215709
+CD.16	Haut-Uele	Haut-Uele	216140
+CD.15	Haut-Lomami	Haut-Lomami	216141
 CD.02	Équateur	Equateur	216661
+CD.13	Bas-Uele	Bas-Uele	219402
+CD.22	Lualaba	Lualaba	922727
+CD.24	Mai-Ndombe	Mai-Ndombe	2313191
+CD.20	Kwilu	Kwilu	2313847
+CD.19	Kwango	Kwango	2313860
 CD.06	Kinshasa	Kinshasa	2314300
 CD.08	Bas-Congo	Bas-Congo	2317277
-CD.01	Bandundu	Bandundu	2317396
+CD.14	Haut-Katanga	Haut-Katanga	11288213
+CD.21	Lomami	Lomami	11288214
+CD.26	Nord-Ubangi	Nord-Ubangi	11288215
+CD.28	Sud-Ubangi	Sud-Ubangi	11288216
 CF.14	Vakaga	Vakaga	236178
 CF.11	Ouaka	Ouaka	236887
 CF.08	Mbomou	Mbomou	237556
@@ -477,7 +513,7 @@ CF.01	Bamingui-Bangoran	Bamingui-Bangoran	240591
 CF.16	Sangha-Mbaéré	Sangha-Mbaere	2383204
 CF.13	Ouham-Pendé	Ouham-Pende	2383650
 CF.12	Ouham	Ouham	2383653
-CF.17	Ombella-Mpoko	Ombella-Mpoko	2383765
+CF.17	Ombella-M'Poko	Ombella-M'Poko	2383765
 CF.09	Nana-Mambéré	Nana-Mambere	2384205
 CF.07	Lobaye	Lobaye	2385105
 CF.06	Kémo	Kemo	2385836
@@ -495,7 +531,7 @@ CG.13	Cuvette	Cuvette	2260487
 CG.01	Bouenza	Bouenza	2260668
 CG.12	Brazzaville	Brazzaville	2572183
 CG.14	Cuvette-Ouest	Cuvette-Ouest	2593118
-CG.7280295	Pointe-Noire	Pointe-Noire	7280295
+CG.15	Pointe-Noire	Pointe-Noire	7280295
 CH.ZH	Zurich	Zurich	2657895
 CH.ZG	Zug	Zug	2657907
 CH.VD	Vaud	Vaud	2658182
@@ -522,80 +558,87 @@ CH.BL	Basel-Landschaft	Basel-Landschaft	2661603
 CH.AR	Appenzell Ausserrhoden	Appenzell Ausserrhoden	2661739
 CH.AI	Appenzell Innerrhoden	Appenzell Innerrhoden	2661741
 CH.AG	Aargau	Aargau	2661876
-CI.82	Lagunes	Lagunes	2597316
-CI.89	Sud-Comoé	Sud-Comoe	2597317
-CI.74	Agnéby	Agneby	2597318
-CI.80	Haut-Sassandra	Haut-Sassandra	2597319
-CI.87	Savanes	Savanes	2597320
-CI.90	Vallée du Bandama	Vallee du Bandama	2597321
-CI.85	Moyen-Comoé	Moyen-Comoe	2597322
-CI.78	Dix-Huit Montagnes	Dix-Huit Montagnes	2597323
-CI.81	Lacs	Lacs	2597324
-CI.92	Zanzan	Zanzan	2597325
-CI.76	Bas-Sassandra	Bas-Sassandra	2597326
-CI.91	Worodougou	Worodougou	2597327
-CI.77	Denguélé	Denguele	2597328
-CI.88	Sud-Bandama	Sud-Bandama	2597329
-CI.79	Fromager	Fromager	2597330
-CI.86	Nʼzi-Comoé	N'zi-Comoe	2597331
-CI.83	Marahoué	Marahoue	2597332
-CI.84	Moyen-Cavally	Moyen-Cavally	2597333
-CI.75	Bafing	Bafing	2597334
+CI.98	Yamoussoukro	Yamoussoukro	10629377
+CI.76	Bas-Sassandra	Bas-Sassandra	11153052
+CI.94	Comoé	Comoe	11153053
+CI.77	Denguélé	Denguele	11153054
+CI.95	Gôh-Djiboua	Goh-Djiboua	11153055
+CI.81	Lacs	Lacs	11153056
+CI.82	Lagunes	Lagunes	11153057
+CI.78	Montagnes	Montagnes	11153058
+CI.96	Sassandra-Marahoué	Sassandra-Marahoue	11153059
+CI.87	Savanes	Savanes	11153060
+CI.90	Vallée du Bandama	Vallee du Bandama	11153061
+CI.97	Woroba	Woroba	11153062
+CI.92	Zanzan	Zanzan	11153063
+CI.93	Abidjan	Abidjan	11153151
+CK.11695124	Aitutaki	Aitutaki	11695124
+CK.11695126	Atiu	Atiu	11695126
+CK.11695127	Mangaia	Mangaia	11695127
+CK.11695384	Manihiki	Manihiki	11695384
+CK.11695385	Ma'uke	Ma'uke	11695385
+CK.11695386	Mitiaro	Mitiaro	11695386
+CK.11695387	Palmerston	Palmerston	11695387
+CK.11695388	Penrhyn	Penrhyn	11695388
+CK.11695389	Pukapuka	Pukapuka	11695389
+CK.11695390	Rakahanga	Rakahanga	11695390
+CK.11695425	Rarotonga	Rarotonga	11695425
 CL.01	Valparaíso	Valparaiso	3868621
 CL.15	Tarapacá	Tarapaca	3870116
 CL.12	Santiago Metropolitan	Santiago Metropolitan	3873544
-CL.11	Maule	Maule	3880306
-CL.14	Los Lagos	Los Lagos	3881974
-CL.08	O'Higgins	O'Higgins	3883281
-CL.07	Coquimbo	Coquimbo	3893623
+CL.11	Maule Region	Maule Region	3880306
+CL.14	Los Lagos Region	Los Lagos Region	3881974
+CL.08	O'Higgins Region	O'Higgins Region	3883281
+CL.07	Coquimbo Region	Coquimbo Region	3893623
 CL.06	Biobío	Biobio	3898380
 CL.05	Atacama	Atacama	3899191
 CL.04	Araucanía	Araucania	3899463
 CL.03	Antofagasta	Antofagasta	3899537
-CL.02	Aisén	Aisen	3900333
-CL.10	Magallanes	Magallanes	4036650
+CL.02	Aysén	Aysen	3900333
+CL.10	Region of Magallanes	Region of Magallanes	4036650
 CL.16	Arica y Parinacota	Arica y Parinacota	6693562
-CL.17	Los Ríos	Los Rios	6693563
-CM.09	South-West Province	South-West Province	2221788
-CM.14	South Province	South Province	2221789
+CL.17	Los Ríos Region	Los Rios Region	6693563
+CL.18	Ñuble	Nuble	11979367
+CM.09	South-West	South-West	2221788
+CM.14	South	South	2221789
 CM.08	West	West	2222934
-CM.07	North-West Province	North-West Province	2223602
-CM.13	North Province	North Province	2223603
+CM.07	North-West	North-West	2223602
+CM.13	North	North	2223603
 CM.05	Littoral	Littoral	2229336
 CM.12	Far North	Far North	2231755
 CM.04	East	East	2231835
 CM.11	Centre	Centre	2233376
 CM.10	Adamaoua	Adamaoua	2236015
-CN.14	Tibet Autonomous Region	Tibet Autonomous Region	1279685
-CN.06	Qinghai Sheng	Qinghai Sheng	1280239
-CN.13	Xinjiang Uygur Zizhiqu	Xinjiang Uygur Zizhiqu	1529047
-CN.02	Zhejiang Sheng	Zhejiang Sheng	1784764
+CN.14	Tibet	Tibet	1279685
+CN.06	Qinghai	Qinghai	1280239
+CN.13	Xinjiang	Xinjiang	1529047
+CN.02	Zhejiang	Zhejiang	1784764
 CN.29	Yunnan	Yunnan	1785694
-CN.28	Tianjin Shi	Tianjin Shi	1792943
+CN.28	Tianjin	Tianjin	1792943
 CN.32	Sichuan	Sichuan	1794299
-CN.24	Shanxi Sheng	Shanxi Sheng	1795912
-CN.23	Shanghai Shi	Shanghai Shi	1796231
-CN.25	Shandong Sheng	Shandong Sheng	1796328
+CN.24	Shanxi	Shanxi	1795912
+CN.23	Shanghai	Shanghai	1796231
+CN.25	Shandong	Shandong	1796328
 CN.26	Shaanxi	Shaanxi	1796480
-CN.21	Ningxia Huizu Zizhiqu	Ningxia Huizu Zizhiqu	1799355
-CN.03	Jiangxi Sheng	Jiangxi Sheng	1806222
-CN.04	Jiangsu Sheng	Jiangsu Sheng	1806260
+CN.21	Ningxia Hui Autonomous Region	Ningxia Hui Autonomous Region	1799355
+CN.03	Jiangxi	Jiangxi	1806222
+CN.04	Jiangsu	Jiangsu	1806260
 CN.11	Hunan	Hunan	1806691
 CN.12	Hubei	Hubei	1806949
-CN.09	Henan Sheng	Henan Sheng	1808520
+CN.09	Henan	Henan	1808520
 CN.10	Hebei	Hebei	1808773
 CN.31	Hainan	Hainan	1809054
-CN.18	Guizhou Sheng	Guizhou Sheng	1809445
-CN.16	Guangxi Zhuangzu Zizhiqu	Guangxi Zhuangzu Zizhiqu	1809867
+CN.18	Guizhou	Guizhou	1809445
+CN.16	Guangxi	Guangxi	1809867
 CN.30	Guangdong	Guangdong	1809935
-CN.15	Gansu Sheng	Gansu Sheng	1810676
+CN.15	Gansu	Gansu	1810676
 CN.07	Fujian	Fujian	1811017
-CN.33	Chongqing Shi	Chongqing Shi	1814905
-CN.01	Anhui Sheng	Anhui Sheng	1818058
+CN.33	Chongqing	Chongqing	1814905
+CN.01	Anhui	Anhui	1818058
 CN.20	Inner Mongolia	Inner Mongolia	2035607
 CN.19	Liaoning	Liaoning	2036115
-CN.05	Jilin Sheng	Jilin Sheng	2036500
-CN.08	Heilongjiang Sheng	Heilongjiang Sheng	2036965
+CN.05	Jilin	Jilin	2036500
+CN.08	Heilongjiang	Heilongjiang	2036965
 CN.22	Beijing	Beijing	2038349
 CO.31	Vichada	Vichada	3666082
 CO.30	Vaupés	Vaupes	3666254
@@ -603,53 +646,53 @@ CO.29	Valle del Cauca	Valle del Cauca	3666313
 CO.28	Tolima	Tolima	3666951
 CO.27	Sucre	Sucre	3667725
 CO.26	Santander	Santander	3668578
-CO.25	Archipiélago de San Andrés, Providencia y Santa Catalina	Archipielago de San Andres, Providencia y Santa Catalina	3670205
+CO.25	San Andres y Providencia	San Andres y Providencia	3670205
 CO.24	Risaralda	Risaralda	3670698
 CO.23	Quindío	Quindio	3671087
 CO.22	Putumayo	Putumayo	3671178
-CO.21	Norte de Santander	Norte de Santander	3673798
+CO.21	Norte de Santander Department	Norte de Santander Department	3673798
 CO.20	Nariño	Narino	3674021
 CO.19	Meta	Meta	3674810
 CO.38	Magdalena	Magdalena	3675686
-CO.17	La Guajira	La Guajira	3678847
+CO.17	La Guajira Department	La Guajira Department	3678847
 CO.16	Huila	Huila	3680692
 CO.14	Guaviare	Guaviare	3681344
-CO.15	Guainía	Guainia	3681652
+CO.15	Guainía Department	Guainia Department	3681652
 CO.33	Cundinamarca	Cundinamarca	3685413
 CO.12	Córdoba	Cordoba	3685889
 CO.11	Chocó	Choco	3686431
 CO.10	Cesar	Cesar	3686880
 CO.09	Cauca	Cauca	3687029
-CO.32	Casanare	Casanare	3687173
+CO.32	Casanare Department	Casanare Department	3687173
 CO.08	Caquetá	Caqueta	3687479
-CO.37	Caldas	Caldas	3687951
+CO.37	Caldas Department	Caldas Department	3687951
 CO.36	Boyacá	Boyaca	3688536
 CO.35	Bolívar	Bolivar	3688650
 CO.34	Bogota D.C.	Bogota D.C.	3688685
 CO.04	Atlántico	Atlantico	3689436
-CO.03	Arauca	Arauca	3689717
+CO.03	Departamento de Arauca	Departamento de Arauca	3689717
 CO.02	Antioquia	Antioquia	3689815
 CO.01	Amazonas	Amazonas	3689982
 CR.08	San José	San Jose	3621837
-CR.07	Puntarenas	Puntarenas	3622226
-CR.06	Limón	Limon	3623064
-CR.04	Heredia	Heredia	3623484
-CR.03	Guanacaste	Guanacaste	3623582
-CR.02	Cartago	Cartago	3624368
-CR.01	Alajuela	Alajuela	3624953
-CU.16	Villa Clara	Villa Clara	3534168
+CR.07	Puntarenas Province	Puntarenas Province	3622226
+CR.06	Limón Province	Limon Province	3623064
+CR.04	Heredia Province	Heredia Province	3623484
+CR.03	Guanacaste Province	Guanacaste Province	3623582
+CR.02	Cartago Province	Cartago Province	3624368
+CR.01	Alajuela Province	Alajuela Province	3624953
+CU.16	Villa Clara Province	Villa Clara Province	3534168
 CU.15	Santiago de Cuba	Santiago de Cuba	3536725
-CU.14	Sancti Spíritus	Sancti Spiritus	3540665
+CU.14	Sancti Spíritus Province	Sancti Spiritus Province	3540665
 CU.01	Pinar del Río	Pinar del Rio	3544088
-CU.03	Matanzas	Matanzas	3547394
+CU.03	Matanzas Province	Matanzas Province	3547394
 CU.13	Las Tunas	Las Tunas	3550595
 CU.04	Isla de la Juventud	Isla de la Juventud	3556608
-CU.12	Holguín	Holguin	3556965
-CU.10	Guantánamo	Guantanamo	3557685
-CU.09	Granma	Granma	3558052
-CU.02	La Habana	La Habana	3564073
-CU.08	Cienfuegos	Cienfuegos	3564120
-CU.07	Ciego de Ávila	Ciego de Avila	3564175
+CU.12	Holguín Province	Holguin Province	3556965
+CU.10	Guantánamo Province	Guantanamo Province	3557685
+CU.09	Granma Province	Granma Province	3558052
+CU.02	Havana	Havana	3564073
+CU.08	Cienfuegos Province	Cienfuegos Province	3564120
+CU.07	Ciego de Ávila Province	Ciego de Avila Province	3564175
 CU.05	Camagüey	Camaguey	3566062
 CU.AR	Artemisa	Artemisa	7668824
 CU.MA	Mayabeque	Mayabeque	7668827
@@ -676,24 +719,24 @@ CV.27	Tarrafal de São Nicolau	Tarrafal de Sao Nicolau	7602872
 CV.25	São Lourenço dos Órgãos	Sao Lourenco dos Orgaos	7602873
 CV.23	Ribeira Grande de Santiago	Ribeira Grande de Santiago	7603281
 CY.06	Pafos	Pafos	146213
-CY.04	Lefkosia	Lefkosia	146267
+CY.04	Nicosia	Nicosia	146267
 CY.05	Limassol	Limassol	146383
 CY.03	Larnaka	Larnaka	146398
 CY.02	Keryneia	Keryneia	146411
 CY.01	Ammochostos	Ammochostos	146615
-CZ.52	Praha	Praha	3067695
+CZ.52	Prague	Prague	3067695
 CZ.78	South Moravian	South Moravian	3339536
-CZ.79	Jihočeský	Jihocesky	3339537
+CZ.79	Jihočeský kraj	Jihocesky kraj	3339537
 CZ.80	Vysočina	Vysocina	3339538
-CZ.81	Karlovarský	Karlovarsky	3339539
-CZ.82	Královéhradecký	Kralovehradecky	3339540
-CZ.83	Liberecký	Liberecky	3339541
+CZ.81	Karlovarský kraj	Karlovarsky kraj	3339539
+CZ.82	Královéhradecký kraj	Kralovehradecky kraj	3339540
+CZ.83	Liberecký kraj	Liberecky kraj	3339541
 CZ.84	Olomoucký	Olomoucky	3339542
 CZ.85	Moravskoslezský	Moravskoslezsky	3339573
 CZ.86	Pardubický	Pardubicky	3339574
-CZ.87	Plzeňský	Plzensky	3339575
+CZ.87	Plzeň Region	Plzen Region	3339575
 CZ.88	Central Bohemia	Central Bohemia	3339576
-CZ.89	Ústecký	Ustecky	3339577
+CZ.89	Ústecký kraj	Ustecky kraj	3339577
 CZ.90	Zlín	Zlin	3339578
 DE.15	Thuringia	Thuringia	2822542
 DE.10	Schleswig-Holstein	Schleswig-Holstein	2838632
@@ -710,7 +753,7 @@ DE.03	Bremen	Bremen	2944387
 DE.11	Brandenburg	Brandenburg	2945356
 DE.16	Berlin	Berlin	2950157
 DE.02	Bavaria	Bavaria	2951839
-DE.01	Baden-Württemberg	Baden-Wuerttemberg	2953481
+DE.01	Baden-Wurttemberg	Baden-Wurttemberg	2953481
 DJ.05	Tadjourah	Tadjourah	220781
 DJ.04	Obock	Obock	221525
 DJ.07	Djibouti	Djibouti	223818
@@ -771,28 +814,28 @@ DZ.55	Tipaza	Tipaza	2476027
 DZ.54	Tindouf	Tindouf	2476302
 DZ.13	Tiaret	Tiaret	2476893
 DZ.33	Tébessa	Tebessa	2477457
-DZ.53	Tamanghasset	Tamanghasset	2478217
+DZ.53	Tamanrasset	Tamanrasset	2478217
 DZ.52	Souk Ahras	Souk Ahras	2479213
 DZ.31	Skikda	Skikda	2479532
 DZ.30	Sidi Bel Abbès	Sidi Bel Abbes	2481001
 DZ.12	Sétif	Setif	2481696
-DZ.10	Saïda	Saida	2482557
+DZ.10	Saida	Saida	2482557
 DZ.51	Relizane	Relizane	2483666
 DZ.29	Oum el Bouaghi	Oum el Bouaghi	2484618
 DZ.50	Ouargla	Ouargla	2485794
 DZ.09	Oran	Oran	2485920
-DZ.49	Naama النعامة	Wilaya de Naama	2486512
-DZ.27	Mʼsila	Wilaya de M'Sila	2486682
+DZ.49	Naama	Naama	2486512
+DZ.27	M'Sila	M'Sila	2486682
 DZ.07	Mostaganem	Mostaganem	2487130
 DZ.48	Mila	Mila	2487449
-DZ.06	Médéa	Medea	2488831
+DZ.06	Medea	Medea	2488831
 DZ.26	Mascara	Mascara	2490095
 DZ.25	Laghouat	Laghouat	2491188
 DZ.47	Khenchela	Khenchela	2491887
 DZ.24	Jijel	Jijel	2492910
 DZ.46	Illizi	Illizi	2493455
 DZ.23	Guelma	Guelma	2495659
-DZ.45	Ghardaïa	Ghardaia	2496045
+DZ.45	Ghardaia	Ghardaia	2496045
 DZ.44	El Tarf	El Tarf	2497322
 DZ.43	El Oued	El Oued	2497406
 DZ.42	El Bayadh	El Bayadh	2498541
@@ -804,14 +847,24 @@ DZ.21	Bouira	Bouira	2502951
 DZ.39	Bordj Bou Arréridj	Bordj Bou Arreridj	2503699
 DZ.20	Blida	Blida	2503765
 DZ.19	Biskra	Biskra	2503822
-DZ.18	Bejaïa	Bejaia	2505325
+DZ.18	Béjaïa	Bejaia	2505325
 DZ.38	Béchar	Bechar	2505525
 DZ.03	Batna	Batna	2505569
 DZ.37	Annaba	Annaba	2506994
-DZ.01	Alger	Alger	2507475
-DZ.36	Aïn Temouchent	Ain Temouchent	2507899
+DZ.01	Algiers	Algiers	2507475
+DZ.36	Aïn Témouchent	Ain Temouchent	2507899
 DZ.35	Aïn Defla	Ain Defla	2508226
 DZ.34	Adrar	Adrar	2508807
+DZ.BB	Bordj Badji Mokhtar	Bordj Badji Mokhtar	12226383
+DZ.TM	Timimoun	Timimoun	12226384
+DZ.BA	Beni Abbes	Beni Abbes	12226385
+DZ.IG	In Guezzam	In Guezzam	12226386
+DZ.IS	In Salah	In Salah	12226387
+DZ.DJ	Djanet	Djanet	12226388
+DZ.EM	El Menia	El Menia	12226389
+DZ.TG	Touggourt	Touggourt	12226390
+DZ.MG	El Mghair	El Mghair	12226391
+DZ.OD	Ouled Djellal	Ouled Djellal	12226392
 EC.20	Zamora-Chinchipe	Zamora-Chinchipe	3649953
 EC.19	Tungurahua	Tungurahua	3650445
 EC.18	Pichincha	Pichincha	3653224
@@ -850,41 +903,40 @@ EE.05	Jõgevamaa	Jogevamaa	591901
 EE.04	Järvamaa	Jaervamaa	591961
 EE.03	Ida-Virumaa	Ida-Virumaa	592075
 EE.02	Hiiumaa	Hiiumaa	592133
-EE.01	Harju	Harju	592170
-EG.24	Sūhāj	Suhaj	347794
-EG.27	Shamāl Sīnāʼ	Muhafazat Shamal Sina'	349401
-EG.23	Qinā	Qina	350546
-EG.22	Muḩāfaz̧at Maţrūḩ	Muhafazat Matruh	352603
-EG.21	Kafr ash Shaykh	Kafr ash Shaykh	354500
+EE.01	Harjumaa	Harjumaa	592170
+EG.24	Sohag	Sohag	347794
+EG.27	North Sinai	North Sinai	349401
+EG.23	Qena	Qena	350546
+EG.22	Matruh	Matruh	352603
+EG.21	Kafr el-Sheikh	Kafr el-Sheikh	354500
 EG.26	South Sinai	South Sinai	355182
-EG.20	Dumyāţ	Dumyat	358044
-EG.19	Muḩāfaz̧at Būr Sa‘īd	Muhafazat Bur Sa`id	358617
-EG.18	Muḩāfaz̧at Banī Suwayf	Muhafazat Bani Suwayf	359171
-EG.17	Asyūţ	Asyut	359781
-EG.16	Aswān	Aswan	359787
-EG.15	As Suways	As Suways	359797
-EG.14	Eastern Province	Eastern Province	360016
-EG.13	Muḩāfaz̧at al Wādī al Jadīd	Muhafazat al Wadi al Jadid	360483
-EG.12	Muḩāfaz̧at al Qalyūbīyah	Muhafazat al Qalyubiyah	360621
-EG.11	Muḩāfaz̧at al Qāhirah	Muhafazat al Qahirah	360631
-EG.10	Al Minyā	Al Minya	360688
-EG.09	Muḩāfaz̧at al Minūfīyah	Muhafazat al Minufiyah	360689
-EG.08	Al Jīzah	Al Jizah	360997
-EG.07	Al Ismā‘īlīyah	Al Isma'iliyah	361056
+EG.20	Damietta	Damietta	358044
+EG.19	Port Said	Port Said	358617
+EG.18	Beni Suweif	Beni Suweif	359171
+EG.17	Asyut	Asyut	359781
+EG.16	Aswan	Aswan	359787
+EG.15	Suez	Suez	359797
+EG.14	Sharqia	Sharqia	360016
+EG.13	New Valley	New Valley	360483
+EG.12	Qalyubia	Qalyubia	360621
+EG.11	Cairo	Cairo	360631
+EG.10	Minya	Minya	360688
+EG.09	Monufia	Monufia	360689
+EG.08	Giza	Giza	360997
+EG.07	Ismailia	Ismailia	361056
 EG.06	Alexandria	Alexandria	361059
-EG.05	Muḩāfaz̧at al Gharbīyah	Muhafazat al Gharbiyah	361294
-EG.04	Muḩāfaz̧at al Fayyūm	Muhafazat al Fayyum	361323
-EG.03	Al Buḩayrah	Al Buhayrah	361370
+EG.05	Gharbia	Gharbia	361294
+EG.04	Faiyum	Faiyum	361323
+EG.03	Beheira	Beheira	361370
 EG.02	Red Sea	Red Sea	361468
-EG.01	Muḩāfaz̧at ad Daqahlīyah	Muhafazat ad Daqahliyah	361849
+EG.01	Dakahlia	Dakahlia	361849
 EG.28	Luxor	Luxor	7603259
-EH.CE	Oued Ed-Dahab-Lagouira	Oued Ed-Dahab-Lagouira	6547304
-ER.01	Ānseba	Anseba	448497
+ER.01	Anseba	Anseba	448497
 ER.02	Debub	Debub	448498
-ER.03	Debubawī Kʼeyih Bahrī	Southern Red Sea Region	448499
-ER.04	Gash Barka	Gash Barka	448500
-ER.05	Maʼākel	Maekel Region	448501
-ER.06	Semēnawī Kʼeyih Bahrī	Northern Red Sea Region	448502
+ER.03	Southern Red Sea	Southern Red Sea	448499
+ER.04	Gash-Barka	Gash-Barka	448500
+ER.05	Maekel	Maekel	448501
+ER.06	Northern Red Sea	Northern Red Sea	448502
 ES.31	Murcia	Murcia	2513413
 ES.CE	Ceuta	Ceuta	2519582
 ES.07	Balearic Islands	Balearic Islands	2521383
@@ -904,7 +956,7 @@ ES.56	Catalonia	Catalonia	3336901
 ES.58	Galicia	Galicia	3336902
 ES.59	Basque Country	Basque Country	3336903
 ES.ML	Melilla	Melilla	6362988
-ET.44	Ādīs Ābeba	Adis Abeba	444178
+ET.44	Addis Ababa	Addis Ababa	444178
 ET.45	Āfar	Afar	444179
 ET.46	Amhara	Amhara	444180
 ET.47	Bīnshangul Gumuz	Binshangul Gumuz	444181
@@ -914,31 +966,30 @@ ET.50	Harari	Harari	444184
 ET.51	Oromiya	Oromiya	444185
 ET.52	Somali	Somali	444186
 ET.53	Tigray	Tigray	444187
-ET.54	Southern Nations, Nationalities, and People's Region	Southern Nations, Nationalities, and People's Region	444188
+ET.54	SNNPR	SNNPR	444188
 FI.19	Lapland	Lapland	830603
 FI.18	Kainuu	Kainuu	830664
-FI.17	Northern Ostrobothnia	Northern Ostrobothnia	830667
+FI.17	North Ostrobothnia	North Ostrobothnia	830667
 FI.16	Central Ostrobothnia	Central Ostrobothnia	830675
 FI.15	Ostrobothnia	Ostrobothnia	830676
-FI.14	Southern Ostrobothnia	Southern Ostrobothnia	830682
+FI.14	South Ostrobothnia	South Ostrobothnia	830682
 FI.13	Central Finland	Central Finland	830685
 FI.12	North Karelia	North Karelia	830686
-FI.11	Northern Savo	Northern Savo	830690
-FI.10	Southern Savonia	Southern Savonia	830695
+FI.11	North Savo	North Savo	830690
+FI.10	South Savo	South Savo	830695
 FI.09	South Karelia	South Karelia	830699
 FI.08	Kymenlaakso	Kymenlaakso	830703
 FI.06	Pirkanmaa	Pirkanmaa	830704
-FI.05	Häme	Haeme	830705
-FI.02	Varsinais-Suomi	Varsinais-Suomi	830708
+FI.05	Kanta-Häme	Kanta-Haeme	830705
+FI.02	Southwest Finland	Southwest Finland	830708
 FI.01	Uusimaa	Uusimaa	830709
-FI.07	Päijänne Tavastia	Paijanne Tavastia	831040
+FI.07	Paijat-Hame	Paijat-Hame	831040
 FI.04	Satakunta	Satakunta	831041
 FJ.05	Western	Western	2194371
 FJ.03	Northern	Northern	2199295
 FJ.01	Central	Central	2205272
 FJ.02	Eastern	Eastern	4036647
 FJ.04	Rotuma	Rotuma	6324593
-FJ.8617786	Kadavu	Kadavu	8617786
 FM.04	Yap	Yap	2081175
 FM.02	Pohnpei	Pohnpei	2081550
 FM.01	Kosrae	Kosrae	2082036
@@ -949,34 +1000,25 @@ FO.ST	Streymoy	Streymoy	2612225
 FO.SA	Sandoy	Sandoy	2614219
 FO.NO	Norðoyar	Nordoyar	2616145
 FO.OS	Eysturoy	Eysturoy	2622387
-FR.B9	Rhône-Alpes	Rhone-Alpes	2983751
-FR.B8	Provence-Alpes-Côte d'Azur	Provence-Alpes-Cote d'Azur	2985244
-FR.B7	Poitou-Charentes	Poitou-Charentes	2986492
-FR.B6	Picardie	Picardie	2987375
-FR.B5	Pays de la Loire	Pays de la Loire	2988289
-FR.B4	Nord-Pas-de-Calais	Nord-Pas-de-Calais	2990119
-FR.B3	Midi-Pyrénées	Midi-Pyrenees	2993955
-FR.B2	Lorraine	Lorraine	2997551
-FR.B1	Limousin	Limousin	2998268
-FR.A9	Languedoc-Roussillon	Languedoc-Roussillon	3007670
-FR.A8	Île-de-France	Ile-de-France	3012874
-FR.A7	Haute-Normandie	Haute-Normandie	3013756
-FR.A6	Franche-Comté	Franche-Comte	3017372
-FR.A5	Corsica	Corsica	3023519
-FR.A4	Champagne-Ardenne	Champagne-Ardenne	3027257
-FR.A3	Centre	Centre	3027939
-FR.A2	Brittany	Brittany	3030293
-FR.A1	Bourgogne	Bourgogne	3030967
-FR.99	Lower Normandy	Lower Normandy	3034693
-FR.98	Auvergne	Auvergne	3035876
-FR.97	Aquitaine	Aquitaine	3037350
-FR.C1	Alsace	Alsace	3038033
+FR.93	Provence-Alpes-Côte d'Azur	Provence-Alpes-Cote d'Azur	2985244
+FR.52	Pays de la Loire	Pays de la Loire	2988289
+FR.11	Île-de-France	Ile-de-France	3012874
+FR.94	Corsica	Corsica	3023519
+FR.24	Centre	Centre	3027939
+FR.53	Brittany	Brittany	3030293
+FR.27	Bourgogne-Franche-Comté	Bourgogne-Franche-Comte	11071619
+FR.75	Nouvelle-Aquitaine	Nouvelle-Aquitaine	11071620
+FR.28	Normandy	Normandy	11071621
+FR.44	Grand Est	Grand Est	11071622
+FR.76	Occitanie	Occitanie	11071623
+FR.32	Hauts-de-France	Hauts-de-France	11071624
+FR.84	Auvergne-Rhône-Alpes	Auvergne-Rhone-Alpes	11071625
 GA.09	Woleu-Ntem	Woleu-Ntem	2396076
 GA.08	Ogooué-Maritime	Ogooue-Maritime	2396924
 GA.07	Ogooué-Lolo	Ogooue-Lolo	2396925
 GA.06	Ogooué-Ivindo	Ogooue-Ivindo	2396926
 GA.05	Nyanga	Nyanga	2397141
-GA.04	Ngounié	Ngounie	2397466
+GA.04	Ngouni	Ngouni	2397466
 GA.03	Moyen-Ogooué	Moyen-Ogooue	2397842
 GA.02	Haut-Ogooué	Haut-Ogooue	2400454
 GA.01	Estuaire	Estuaire	2400682
@@ -992,7 +1034,7 @@ GD.02	Saint David	Saint David	3579932
 GD.01	Saint Andrew	Saint Andrew	3579938
 GD.10	Carriacou and Petite Martinique	Carriacou and Petite Martinique	7303836
 GE.51	T'bilisi	T'bilisi	611716
-GE.04	Ajaria	Ajaria	615929
+GE.04	Achara	Achara	615929
 GE.68	Kvemo Kartli	Kvemo Kartli	865536
 GE.67	Kakheti	Kakheti	865537
 GE.65	Guria	Guria	865538
@@ -1023,12 +1065,19 @@ GH.06	Northern	Northern	2297169
 GH.01	Greater Accra	Greater Accra	2300569
 GH.05	Eastern	Eastern	2301360
 GH.04	Central	Central	2302353
-GH.03	Brong-Ahafo	Brong-Ahafo	2302547
 GH.02	Ashanti	Ashanti	2304116
-GL.05	Qaasuitsup	Qaasuitsup	7602003
+GH.13	Bono	Bono	12105069
+GH.16	Oti	Oti	12105070
+GH.15	North East	North East	12105071
+GH.12	Ahafo	Ahafo	12105072
+GH.14	Bono East	Bono East	12105073
+GH.17	Savannah	Savannah	12105074
+GH.18	Western North	Western North	12105075
 GL.04	Kujalleq	Kujalleq	7602005
 GL.06	Qeqqata	Qeqqata	7602006
 GL.07	Sermersooq	Sermersooq	7602007
+GL.11839534	Qeqertalik	Qeqertalik	11839534
+GL.11839537	Avannaata	Avannaata	11839537
 GM.05	Western	Western	2411683
 GM.04	Upper River	Upper River	2411711
 GM.07	North Bank	North Bank	2412353
@@ -1044,13 +1093,14 @@ GN.L	Labe	Labe	8335089
 GN.M	Mamou	Mamou	8335090
 GN.N	Nzerekore	Nzerekore	8335091
 GP.GP	Guadeloupe	Guadeloupe	6690363
-GQ.03	Annobón	Annobon	2310307
+GQ.03	Annobon	Annobon	2310307
 GQ.04	Bioko Norte	Bioko Norte	2566978
 GQ.05	Bioko Sur	Bioko Sur	2566979
 GQ.06	Centro Sur	Centro Sur	2566980
 GQ.07	Kié-Ntem	Kie-Ntem	2566981
 GQ.08	Litoral	Litoral	2566982
 GQ.09	Wele-Nzas	Wele-Nzas	2566983
+GQ.10	Djibloho	Djibloho	12168385
 GR.736572	Mount Athos	Mount Athos	736572
 GR.ESYE31	Attica	Attica	6692632
 GR.ESYE24	Central Greece	Central Greece	6697800
@@ -1069,7 +1119,7 @@ GT.22	Zacapa	Zacapa	3587586
 GT.21	Totonicapán	Totonicapan	3588257
 GT.20	Suchitepeque	Suchitepeque	3588668
 GT.19	Sololá	Solola	3588697
-GT.18	Santa Rosa	Santa Rosa	3589172
+GT.18	Santa Rosa Department	Santa Rosa Department	3589172
 GT.17	San Marcos	San Marcos	3589801
 GT.16	Sacatepéquez	Sacatepequez	3590686
 GT.15	Retalhuleu	Retalhuleu	3590857
@@ -1078,7 +1128,7 @@ GT.13	Quetzaltenango	Quetzaltenango	3590978
 GT.12	Petén	Peten	3591410
 GT.11	Jutiapa	Jutiapa	3595067
 GT.10	Jalapa	Jalapa	3595236
-GT.09	Izabal	Izabal	3595259
+GT.09	Izabal Department	Izabal Department	3595259
 GT.08	Huehuetenango	Huehuetenango	3595415
 GT.07	Guatemala	Guatemala	3595530
 GT.06	Escuintla	Escuintla	3595802
@@ -1111,7 +1161,7 @@ GW.02	Quinara	Quinara	2370360
 GW.04	Oio	Oio	2371071
 GW.10	Gabú	Gabu	2372533
 GW.06	Cacheu	Cacheu	2374312
-GW.05	Bolama and Bijagos	Bolama and Bijagos	2374689
+GW.05	Bolama	Bolama	2374689
 GW.11	Bissau	Bissau	2374776
 GW.12	Biombo	Biombo	2374820
 GW.01	Bafatá	Bafata	2375255
@@ -1131,64 +1181,64 @@ HK.NTP	Tai Po	Tai Po	1818672
 HK.NSK	Sai Kung	Sai Kung	1819049
 HK.NIS	Islands	Islands	1819708
 HK.HCW	Central and Western	Central and Western	7533598
-HK.HWC	Wanchai	Wanchai	7533607
+HK.HWC	Wan Chai	Wan Chai	7533607
 HK.HEA	Eastern	Eastern	7533608
 HK.HSO	Southern	Southern	7533609
 HK.KYT	Yau Tsim Mong	Yau Tsim Mong	7533610
 HK.KSS	Sham Shui Po	Sham Shui Po	7533611
 HK.KKC	Kowloon City	Kowloon City	7533612
 HK.KWT	Wong Tai Sin	Wong Tai Sin	7533613
-HK.KKT	Kwon Tong	Kwon Tong	7533614
+HK.KKT	Kwun Tong	Kwun Tong	7533614
 HK.NKT	Kwai Tsing	Kwai Tsing	7533615
 HK.NTM	Tuen Mun	Tuen Mun	7533616
 HK.NNO	North	North	7533617
 HK.NST	Sha Tin	Sha Tin	7533618
-HN.18	Yoro	Yoro	3600193
-HN.17	Valle	Valle	3600456
-HN.16	Santa Bárbara	Santa Barbara	3601689
-HN.15	Olancho	Olancho	3604249
-HN.14	Ocotepeque	Ocotepeque	3604318
-HN.13	Lempira	Lempira	3606066
-HN.12	La Paz	La Paz	3607251
+HN.18	Yoro Department	Yoro Department	3600193
+HN.17	Valle Department	Valle Department	3600456
+HN.16	Santa Bárbara Department	Santa Barbara Department	3601689
+HN.15	Olancho Department	Olancho Department	3604249
+HN.14	Ocotepeque Department	Ocotepeque Department	3604318
+HN.13	Lempira Department	Lempira Department	3606066
+HN.12	La Paz Department	La Paz Department	3607251
 HN.11	Bay Islands	Bay Islands	3608814
-HN.10	Intibucá	Intibuca	3608833
-HN.09	Gracias a Dios	Gracias a Dios	3609583
-HN.08	Francisco Morazán	Francisco Morazan	3609672
-HN.07	El Paraíso	El Paraiso	3610942
-HN.06	Cortés	Cortes	3613140
-HN.05	Copán	Copan	3613229
-HN.04	Comayagua	Comayagua	3613319
-HN.03	Colón	Colon	3613358
-HN.02	Choluteca	Choluteca	3613527
-HN.01	Atlántida	Atlantida	3615027
-HR.01	Bjelovarsko-Bilogorska	Bjelovarsko-Bilogorska	3337511
-HR.02	Brodsko-Posavska	Brodsko-Posavska	3337512
-HR.03	Dubrovačko-Neretvanska	Dubrovacko-Neretvanska	3337513
-HR.04	Istarska	Istarska	3337514
-HR.05	Karlovačka	Karlovacka	3337515
-HR.06	Koprivničko-Križevačka	Koprivnicko-Krizevacka	3337518
-HR.07	Krapinsko-Zagorska	Krapinsko-Zagorska	3337519
-HR.08	Ličko-Senjska	Licko-Senjska	3337520
-HR.09	Međimurska	Medimurska	3337521
-HR.10	Osječko-Baranjska	Osjecko-Baranjska	3337522
-HR.11	Požeško-Slavonska	Pozesko-Slavonska	3337523
-HR.12	Primorsko-Goranska	Primorsko-Goranska	3337524
-HR.13	Šibensko-Kniniska	Sibensko-Kniniska	3337525
-HR.14	Sisačko-Moslavačka	Sisacko-Moslavacka	3337526
-HR.15	Splitsko-Dalmatinska	Splitsko-Dalmatinska	3337527
-HR.16	Varaždinska	Varazdinska	3337528
-HR.18	Vukovarsko-Srijemska	Vukovarsko-Srijemska	3337529
-HR.19	Zadarska	Zadarska	3337530
-HR.20	Zagrebačka	Zagrebacka	3337531
-HR.21	Grad Zagreb	Grad Zagreb	3337532
-HR.17	Virovitičk-Podravska	Virovitick-Podravska	3337533
+HN.10	Intibucá Department	Intibuca Department	3608833
+HN.09	Gracias a Dios Department	Gracias a Dios Department	3609583
+HN.08	Francisco Morazán Department	Francisco Morazan Department	3609672
+HN.07	El Paraíso Department	El Paraiso Department	3610942
+HN.06	Cortés Department	Cortes Department	3613140
+HN.05	Copán Department	Copan Department	3613229
+HN.04	Comayagua Department	Comayagua Department	3613319
+HN.03	Colón Department	Colon Department	3613358
+HN.02	Choluteca Department	Choluteca Department	3613527
+HN.01	Atlántida Department	Atlantida Department	3615027
+HR.01	Bjelovar-Bilogora	Bjelovar-Bilogora	3337511
+HR.02	Brod-Posavina	Brod-Posavina	3337512
+HR.03	Dubrovnik-Neretva	Dubrovnik-Neretva	3337513
+HR.04	Istria	Istria	3337514
+HR.05	Karlovac	Karlovac	3337515
+HR.06	County of Koprivnica-Križevci	County of Koprivnica-Krizevci	3337518
+HR.07	County of Krapina-Zagorje	County of Krapina-Zagorje	3337519
+HR.08	County of Lika-Senj	County of Lika-Senj	3337520
+HR.09	County of Međimurje	County of Megimurje	3337521
+HR.10	County of Osijek-Baranja	County of Osijek-Baranja	3337522
+HR.11	County of Požega-Slavonia	County of Pozega-Slavonia	3337523
+HR.12	County of Primorje-Gorski Kotar	County of Primorje-Gorski Kotar	3337524
+HR.13	Šibenik-Knin	Sibenik-Knin	3337525
+HR.14	County of Sisak-Moslavina	County of Sisak-Moslavina	3337526
+HR.15	Split-Dalmatia	Split-Dalmatia	3337527
+HR.16	County of Varaždin	County of Varazdin	3337528
+HR.18	Vukovar-Sirmium	Vukovar-Sirmium	3337529
+HR.19	County of Zadar	County of Zadar	3337530
+HR.20	County of Zagreb	County of Zagreb	3337531
+HR.21	City of Zagreb	City of Zagreb	3337532
+HR.17	County of Virovitica-Podravina	County of Virovitica-Podravina	3337533
 HT.13	Sud-Est	Sud-Est	3716950
 HT.12	Sud	Sud	3716952
 HT.11	Ouest	Ouest	3719432
 HT.03	Nord-Ouest	Nord-Ouest	3719536
 HT.10	Nord-Est	Nord-Est	3719540
 HT.09	Nord	Nord	3719543
-HT.14	GrandʼAnse	Grandans	3724613
+HT.14	GrandʼAnse	Grand'Anse	3724613
 HT.07	Centre	Centre	3728069
 HT.06	Artibonite	Artibonite	3731053
 HT.15	Nippes	Nippes	7115999
@@ -1198,7 +1248,7 @@ HU.11	Heves	Heves	720002
 HU.10	Hajdú-Bihar	Hajdu-Bihar	720293
 HU.06	Csongrád	Csongrad	721589
 HU.04	Borsod-Abaúj-Zemplén	Borsod-Abauj-Zemplen	722064
-HU.03	Bekes	Bekes	722433
+HU.03	Bekes County	Bekes County	722433
 HU.24	Zala	Zala	3042613
 HU.23	Veszprém	Veszprem	3042925
 HU.22	Vas	Vas	3043047
@@ -1214,11 +1264,11 @@ HU.02	Baranya	Baranya	3055399
 HU.01	Bács-Kiskun	Bacs-Kiskun	3055744
 ID.26	North Sumatra	North Sumatra	1213642
 ID.01	Aceh	Aceh	1215638
-ID.10	Daerah Istimewa Yogyakarta	Daerah Istimewa Yogyakarta	1621176
+ID.10	Yogyakarta	Yogyakarta	1621176
 ID.32	South Sumatra	South Sumatra	1626196
 ID.24	West Sumatra	West Sumatra	1626197
 ID.31	North Sulawesi	North Sulawesi	1626229
-ID.22	Sulawesi Tenggara	Sulawesi Tenggara	1626230
+ID.22	Southeast Sulawesi	Southeast Sulawesi	1626230
 ID.21	Central Sulawesi	Central Sulawesi	1626231
 ID.38	South Sulawesi	South Sulawesi	1626232
 ID.37	Riau	Riau	1629652
@@ -1234,19 +1284,23 @@ ID.08	East Java	East Java	1642668
 ID.07	Central Java	Central Java	1642669
 ID.30	West Java	West Java	1642672
 ID.05	Jambi	Jambi	1642856
-ID.04	Jakarta Raya	Jakarta Raya	1642907
+ID.04	Jakarta	Jakarta	1642907
 ID.36	Papua	Papua	1643012
 ID.03	Bengkulu	Bengkulu	1649147
 ID.02	Bali	Bali	1650535
 ID.33	Banten	Banten	1923045
 ID.34	Gorontalo	Gorontalo	1923046
 ID.35	Bangka–Belitung Islands	Bangka-Belitung Islands	1923047
-ID.29	Maluku Utara	Maluku Utara	1958070
+ID.29	North Maluku	North Maluku	1958070
 ID.39	West Papua	West Papua	1996549
-ID.41	Sulawesi Barat	Sulawesi Barat	1996550
+ID.41	West Sulawesi	West Sulawesi	1996550
 ID.40	Riau Islands	Riau Islands	1996551
 ID.42	North Kalimantan	North Kalimantan	8604684
-IE.C	Connaught	Connaught	7521313
+ID.PD	Southwest Papua	Southwest Papua	12503510
+ID.PT	Central Papua	Central Papua	12503511
+ID.PE	Highland Papua	Highland Papua	12503512
+ID.PS	South Papua	South Papua	12503513
+IE.C	Connacht	Connacht	7521313
 IE.L	Leinster	Leinster	7521314
 IE.M	Munster	Munster	7521315
 IE.U	Ulster	Ulster	7521316
@@ -1256,6 +1310,7 @@ IL.04	Haifa	Haifa	294800
 IL.03	Northern District	Northern District	294824
 IL.02	Central District	Central District	294904
 IL.01	Southern District	Southern District	294952
+IL.WE	Judea and Samaria Area	Judea and Samaria Area	11821181
 IM.9782164	Andreas	Andreas	9782164
 IM.9782165	Arbory	Arbory	9782165
 IM.9782166	Ballaugh	Ballaugh	9782166
@@ -1288,7 +1343,7 @@ IN.25	Tamil Nadu	Tamil Nadu	1255053
 IN.29	Sikkim	Sikkim	1256312
 IN.24	Rajasthan	Rajasthan	1258899
 IN.23	Punjab	Punjab	1259223
-IN.22	Pondicherry	Pondicherry	1259424
+IN.22	Puducherry	Puducherry	1259424
 IN.21	Odisha	Odisha	1261029
 IN.20	Nagaland	Nagaland	1262271
 IN.31	Mizoram	Mizoram	1262963
@@ -1299,72 +1354,73 @@ IN.35	Madhya Pradesh	Madhya Pradesh	1264542
 IN.14	Laccadives	Laccadives	1265206
 IN.13	Kerala	Kerala	1267254
 IN.19	Karnataka	Karnataka	1267701
-IN.12	Kashmir	Kashmir	1269320
+IN.12	Jammu and Kashmir	Jammu and Kashmir	1269320
 IN.11	Himachal Pradesh	Himachal Pradesh	1270101
 IN.10	Haryana	Haryana	1270260
 IN.09	Gujarat	Gujarat	1270770
-IN.32	Daman and Diu	Daman and Diu	1271155
 IN.33	Goa	Goa	1271157
-IN.07	NCT	NCT	1273293
-IN.06	Dadra and Nagar Haveli	Dadra and Nagar Haveli	1273726
+IN.07	Delhi	Delhi	1273293
 IN.05	Chandigarh	Chandigarh	1274744
 IN.34	Bihar	Bihar	1275715
 IN.03	Assam	Assam	1278253
 IN.30	Arunachal Pradesh	Arunachal Pradesh	1278341
 IN.02	Andhra Pradesh	Andhra Pradesh	1278629
-IN.01	Andaman and Nicobar Islands	Andaman and Nicobar Islands	1278647
+IN.01	Andaman and Nicobar	Andaman and Nicobar	1278647
 IN.37	Chhattisgarh	Chhattisgarh	1444364
 IN.38	Jharkhand	Jharkhand	1444365
 IN.39	Uttarakhand	Uttarakhand	1444366
-IQ.02	Basra Governorate	Basra Governorate	89341
+IN.41	Ladakh	Ladakh	12096464
+IN.52	Dadra and Nagar Haveli and Daman and Diu	Dadra and Nagar Haveli and Daman and Diu	12165662
+IQ.02	Basra	Basra	89341
 IQ.16	Wāsiţ	Wasit	89693
-IQ.18	Salah ad Din Governorate	Salah ad Din Governorate	91695
-IQ.15	Nīnawá	Ninawa	92877
+IQ.18	Salah ad Din	Salah ad Din	91695
+IQ.15	Nineveh	Nineveh	92877
 IQ.14	Maysan	Maysan	93540
 IQ.12	Karbalāʼ	Muhafazat Karbala'	94823
 IQ.11	Arbīl	Arbil	95445
 IQ.10	Diyālá	Diyala	96965
 IQ.09	Dhi Qar	Dhi Qar	97019
-IQ.08	Dahūk	Dahuk	97270
-IQ.07	Mayorality of Baghdad	Mayorality of Baghdad	98180
+IQ.08	Duhok	Duhok	97270
+IQ.07	Baghdad	Baghdad	98180
 IQ.06	Bābil	Babil	98227
-IQ.13	At Taʼmīm	Muhafazat Kirkuk	98410
-IQ.05	As Sulaymānīyah	As Sulaymaniyah	98465
+IQ.13	Kirkuk	Kirkuk	98410
+IQ.05	Sulaymaniyah	Sulaymaniyah	98465
 IQ.17	An Najaf	An Najaf	98862
 IQ.04	Al Qādisīyah	Al Qadisiyah	99022
 IQ.03	Al Muthanná	Al Muthanna	99032
-IQ.01	Anbar	Anbar	99592
-IR.26	Tehrān	Tehran	110791
+IQ.01	Al Anbar	Al Anbar	99592
+IQ.19	Halabja Governorate	Halabja Governorate	12218240
+IR.26	Tehran	Tehran	110791
 IR.36	Zanjan	Zanjan	111452
 IR.40	Yazd	Yazd	111821
-IR.25	Semnān	Semnan	116401
+IR.25	Semnan	Semnan	116401
 IR.35	Māzandarān	Mazandaran	124544
 IR.34	Markazi	Markazi	124763
-IR.23	Lorestān	Lorestan	125605
+IR.23	Lorestan Province	Lorestan Province	125605
 IR.16	Kordestān	Kordestan	126584
-IR.05	Kohgīlūyeh va Būyer Aḩmad	Kohgiluyeh va Buyer Ahmad	126878
+IR.05	Kohgiluyeh and Boyer-Ahmad	Kohgiluyeh and Boyer-Ahmad	126878
 IR.15	Khuzestan	Khuzestan	127082
 IR.13	Kermānshāh	Kermanshah	128222
 IR.29	Kerman	Kerman	128231
-IR.10	Īlām	Ilam	130801
+IR.10	Ilam Province	Ilam Province	130801
 IR.11	Hormozgan	Hormozgan	131222
 IR.09	Hamadān	Hamadan	132142
 IR.08	Gīlān	Gilan	133349
 IR.07	Fars	Fars	134766
-IR.03	Chahār Maḩāll va Bakhtīārī	Chahar Mahall va Bakhtiari	139677
+IR.03	Chaharmahal and Bakhtiari	Chaharmahal and Bakhtiari	139677
 IR.22	Bushehr	Bushehr	139816
 IR.33	East Azerbaijan	East Azerbaijan	142549
-IR.01	Āz̄ārbāyjān-e Gharbī	Azarbayjan-e Gharbi	142550
+IR.01	West Azerbaijan	West Azerbaijan	142550
 IR.32	Ardabīl	Ardabil	413931
 IR.28	Isfahan	Isfahan	418862
-IR.37	Golestān	Golestan	443792
+IR.37	Golestan	Golestan	443792
 IR.38	Qazvīn	Qazvin	443793
 IR.39	Qom	Qom	443794
 IR.04	Sistan and Baluchestan	Sistan and Baluchestan	1159456
-IR.41	Khorāsān-e Jonūbī	Khorasan-e Jonubi	6201374
+IR.41	South Khorasan Province	South Khorasan Province	6201374
 IR.42	Razavi Khorasan	Razavi Khorasan	6201375
-IR.43	Khorāsān-e Shomālī	Khorasan-e Shomali	6201376
-IR.44	Alborz	Alborz	7648907
+IR.43	North Khorasan	North Khorasan	6201376
+IR.44	Alborz Province	Alborz Province	7648907
 IS.41	Northwest	Northwest	3337403
 IS.40	Northeast	Northeast	3337404
 IS.38	East	East	3337405
@@ -1387,7 +1443,7 @@ IT.11	Molise	Molise	3173222
 IT.10	The Marches	The Marches	3174004
 IT.09	Lombardy	Lombardy	3174618
 IT.08	Liguria	Liguria	3174725
-IT.07	Latium	Latium	3174976
+IT.07	Lazio	Lazio	3174976
 IT.06	Friuli Venezia Giulia	Friuli Venezia Giulia	3176525
 IT.05	Emilia-Romagna	Emilia-Romagna	3177401
 IT.04	Campania	Campania	3181042
@@ -1407,13 +1463,13 @@ JE.3237716	St Martîn	St Martin	3237716
 JE.3237864	St Helier	St Helier	3237864
 JM.16	Westmoreland	Westmoreland	3488081
 JM.15	Trelawny	Trelawny	3488222
-JM.14	Saint Thomas	Saint Thomas	3488688
-JM.13	Saint Mary	Saint Mary	3488693
-JM.12	Saint James	Saint James	3488700
+JM.14	St. Thomas	St. Thomas	3488688
+JM.13	St. Mary	St. Mary	3488693
+JM.12	St. James	St. James	3488700
 JM.11	St. Elizabeth	St. Elizabeth	3488708
 JM.10	Saint Catherine	Saint Catherine	3488711
-JM.09	Saint Ann	Saint Ann	3488715
-JM.08	Saint Andrew	Saint Andrew	3488716
+JM.09	St Ann	St Ann	3488715
+JM.08	St. Andrew	St. Andrew	3488716
 JM.07	Portland	Portland	3488997
 JM.04	Manchester	Manchester	3489586
 JM.17	Kingston	Kingston	3489853
@@ -1436,27 +1492,27 @@ JP.45	Yamaguchi	Yamaguchi	1848681
 JP.43	Wakayama	Wakayama	1848938
 JP.42	Toyama	Toyama	1849872
 JP.41	Tottori	Tottori	1849890
-JP.40	Tōkyō	Tokyo	1850144
+JP.40	Tokyo	Tokyo	1850144
 JP.39	Tokushima	Tokushima	1850157
 JP.38	Tochigi	Tochigi	1850310
 JP.37	Shizuoka	Shizuoka	1851715
 JP.36	Shimane	Shimane	1852442
-JP.35	Shiga Prefecture	Shiga Prefecture	1852553
+JP.35	Shiga	Shiga	1852553
 JP.34	Saitama	Saitama	1853226
-JP.33	Saga Prefecture	Saga Prefecture	1853299
+JP.33	Saga	Saga	1853299
 JP.32	Ōsaka	Osaka	1853904
 JP.47	Okinawa	Okinawa	1854345
 JP.31	Okayama	Okayama	1854381
-JP.30	Ōita	Oita	1854484
+JP.30	Oita	Oita	1854484
 JP.29	Niigata	Niigata	1855429
 JP.28	Nara	Nara	1855608
 JP.27	Nagasaki	Nagasaki	1856156
 JP.26	Nagano	Nagano	1856210
 JP.25	Miyazaki	Miyazaki	1856710
 JP.23	Mie	Mie	1857352
-JP.22	Kyōto	Kyoto	1857907
+JP.22	Kyoto	Kyoto	1857907
 JP.21	Kumamoto	Kumamoto	1858419
-JP.20	Kōchi	Kochi	1859133
+JP.20	Kochi	Kochi	1859133
 JP.19	Kanagawa	Kanagawa	1860291
 JP.18	Kagoshima	Kagoshima	1860825
 JP.17	Kagawa	Kagawa	1860834
@@ -1476,19 +1532,19 @@ JP.14	Ibaraki	Ibaraki	2112669
 JP.08	Fukushima	Fukushima	2112922
 JP.04	Chiba	Chiba	2113014
 JP.02	Akita	Akita	2113124
-JP.12	Hokkaidō	Hokkaido	2130037
+JP.12	Hokkaido	Hokkaido	2130037
 JP.03	Aomori	Aomori	2130656
 KE.55	West Pokot	West Pokot	178145
 KE.54	Wajir	Wajir	178440
 KE.52	Uasin Gishu	Uasin Gishu	178837
 KE.51	Turkana	Turkana	178914
 KE.50	Trans Nzoia	Trans Nzoia	179068
-KE.49	Tharaka - Nithi	Tharaka District	179380
+KE.49	Tharaka - Nithi	Tharaka - Nithi	179380
 KE.48	Tana River	Tana River	179585
 KE.46	Siaya	Siaya	180320
 KE.45	Samburu	Samburu	180782
 KE.05	Nairobi Area	Nairobi Area	184742
-KE.38	Murang'A	Murang'a District	185578
+KE.38	Murang'A	Murang'A	185578
 KE.37	Mombasa	Mombasa	186298
 KE.35	Meru	Meru	186824
 KE.34	Marsabit	Marsabit	187583
@@ -1521,19 +1577,19 @@ KE.44	Nyeri	Nyeri	7667661
 KE.17	Homa Bay	Homa Bay	7667665
 KE.11	Bomet	Bomet	7667666
 KE.36	Migori	Migori	7667678
-KE.08	Keiyo	Keiyo	7668899
 KE.39	Nakuru	Nakuru	7668902
 KE.41	Narok	Narok	7668904
-KE.42	Nyamira	Nyamira District	7806857
+KE.42	Nyamira	Nyamira	7806857
 KE.40	Nandi	Nandi	8051212
 KG.08	Osh	Osh	1346798
 KG.09	Batken	Batken	1463580
 KG.06	Talas	Talas	1527297
 KG.04	Naryn	Naryn	1527590
-KG.07	Ysyk-Köl	Ysyk-Koel	1528260
+KG.07	Issyk-Kul	Issyk-Kul	1528260
 KG.01	Bishkek	Bishkek	1528334
 KG.03	Jalal-Abad	Jalal-Abad	1529778
 KG.02	Chüy	Chuy	1538652
+KG.10	Osh City	Osh City	10300944
 KH.12	Pursat	Pursat	1821301
 KH.29	Battambang	Battambang	1821310
 KH.19	Takeo	Takeo	1821939
@@ -1558,6 +1614,7 @@ KH.03	Kampong Chhnang	Kampong Chhnang	1831166
 KH.02	Kampong Cham	Kampong Cham	1831172
 KH.28	Preah Sihanouk	Preah Sihanouk	1899262
 KH.25	Banteay Meanchey	Banteay Meanchey	1899273
+KH.31	Tboung Khmum	Tboung Khmum	7647525
 KI.01	Gilbert Islands	Gilbert Islands	2110215
 KI.02	Line Islands	Line Islands	4030940
 KI.03	Phoenix Islands	Phoenix Islands	7521379
@@ -1565,7 +1622,7 @@ KM.03	Mohéli	Moheli	921780
 KM.02	Grande Comore	Grande Comore	921882
 KM.01	Anjouan	Anjouan	922001
 KN.15	Trinity Palmetto Point	Trinity Palmetto Point	3575114
-KN.13	Saint Thomas Middle Island	Saint Thomas Middle Island	3575164
+KN.13	Middle Island	Middle Island	3575164
 KN.12	Saint Thomas Lowland	Saint Thomas Lowland	3575165
 KN.11	Saint Peter Basseterre	Saint Peter Basseterre	3575168
 KN.10	Saint Paul Charlestown	Saint Paul Charlestown	3575171
@@ -1579,14 +1636,14 @@ KN.03	Saint George Basseterre	Saint George Basseterre	3575180
 KN.02	Saint Anne Sandy Point	Saint Anne Sandy Point	3575183
 KN.01	Christ Church Nichola Town	Christ Church Nichola Town	3575476
 KP.12	Pyongyang	Pyongyang	1871856
-KP.15	P'yŏngan-namdo	P'yongan-namdo	1871952
+KP.15	South Pyongan	South Pyongan	1871952
 KP.11	P'yŏngan-bukto	P'yongan-bukto	1871954
 KP.09	Kangwŏn-do	Kangwon-do	1876101
 KP.06	Hwanghae-namdo	Hwanghae-namdo	1876884
 KP.07	Hwanghae-bukto	Hwanghae-bukto	1876888
 KP.03	Hamgyŏng-namdo	Hamgyong-namdo	1877450
 KP.13	Yanggang-do	Yanggang-do	2039332
-KP.17	Hamgyŏng-bukto	Hamgyong-bukto	2044245
+KP.17	Hambuk	Hambuk	2044245
 KP.01	Chagang-do	Chagang-do	2045265
 KP.18	Rason	Rason	2054927
 KR.21	Ulsan	Ulsan	1833742
@@ -1600,35 +1657,45 @@ KR.18	Gwangju	Gwangju	1841808
 KR.06	Gangwon-do	Gangwon-do	1843125
 KR.12	Incheon	Incheon	1843561
 KR.17	Chungcheongnam-do	Chungcheongnam-do	1845105
-KR.05	Chungcheongbuk-do	Chungcheongbuk-do	1845106
+KR.05	North Chungcheong	North Chungcheong	1845106
 KR.16	Jeollanam-do	Jeollanam-do	1845788
 KR.03	Jeollabuk-do	Jeollabuk-do	1845789
 KR.01	Jeju-do	Jeju-do	1846265
 KR.20	Gyeongsangnam-do	Gyeongsangnam-do	1902028
 KR.22	Sejong-si	Sejong-si	8394437
-KW.08	Muḩāfaz̧at Ḩawallī	Muhafazat Hawalli	285628
+KW.08	Hawalli	Hawalli	285628
 KW.02	Al Asimah	Al Asimah	285788
 KW.05	Al Jahrāʼ	Muhafazat al Jahra'	285798
 KW.07	Al Farwaniyah	Al Farwaniyah	285816
 KW.04	Al Aḩmadī	Al Ahmadi	285841
 KW.09	Mubārak al Kabīr	Mubarak al Kabir	7733358
+KY.10346796	George Town	George Town	10346796
+KY.10375968	West Bay	West Bay	10375968
+KY.10375969	Bodden Town	Bodden Town	10375969
+KY.10375970	North Side	North Side	10375970
+KY.10375971	East End	East End	10375971
+KY.10375972	Sister Island	Sister Island	10375972
 KZ.07	Batys Qazaqstan	Batys Qazaqstan	607847
 KZ.09	Mangghystaū	Mangghystau	608879
 KZ.06	Atyraū	Atyrau	609862
 KZ.04	Aqtöbe	Aqtoebe	610688
 KZ.15	East Kazakhstan	East Kazakhstan	1517381
 KZ.03	Aqmola	Aqmola	1518003
-KZ.16	Soltüstik Qazaqstan	Soltustik Qazaqstan	1519367
-KZ.11	Pavlodar	Pavlodar	1520239
+KZ.16	North Kazakhstan	North Kazakhstan	1519367
+KZ.11	Pavlodar Region	Pavlodar Region	1520239
 KZ.14	Qyzylorda	Qyzylorda	1521406
 KZ.13	Qostanay	Qostanay	1521671
-KZ.12	Qaraghandy	Qaraghandy	1523401
+KZ.12	Karaganda	Karaganda	1523401
 KZ.17	Zhambyl	Zhambyl	1524444
-KZ.10	Ongtüstik Qazaqstan	Ongtustik Qazaqstan	1524787
-KZ.02	Almaty Qalasy	Almaty Qalasy	1526395
+KZ.10	South Kazakhstan	South Kazakhstan	1524787
+KZ.02	Almaty	Almaty	1526395
 KZ.01	Almaty Oblysy	Almaty Oblysy	1537162
-KZ.08	Bayqongyr Qalasy	Bayqongyr Qalasy	1538316
-KZ.05	Astana Qalasy	Astana Qalasy	1538317
+KZ.1537272	Shymkent	Shymkent	1537272
+KZ.08	Baikonur	Baikonur	1538316
+KZ.05	Astana	Astana	1538317
+KZ.12510143	Abai Region	Abai Region	12510143
+KZ.12510144	Jetisu Region	Jetisu Region	12510144
+KZ.12510145	Ulytau Region	Ulytau Region	12510145
 LA.14	Xiangkhoang	Xiangkhoang	1652077
 LA.13	Xiagnabouli	Xiagnabouli	1652210
 LA.27	Vientiane	Vientiane	1652238
@@ -1643,28 +1710,28 @@ LA.03	Houaphan	Houaphan	1657114
 LA.02	Champasak	Champasak	1657818
 LA.01	Attapu	Attapu	1665045
 LA.26	Xékong	Xekong	1904615
-LA.22	Bokèo	Bokeo	1904616
-LA.23	Bolikhamxai	Bolikhamxai	1904617
-LA.24	Vientiane	Vientiane	1904618
+LA.22	Bokeo	Bokeo	1904616
+LA.23	Bolikhamsai	Bolikhamsai	1904617
+LA.24	Vientiane Prefecture	Vientiane Prefecture	1904618
+LA.28	Xaisomboun	Xaisomboun	11395958
 LB.05	Mont-Liban	Mont-Liban	273607
 LB.04	Beyrouth	Beyrouth	276780
 LB.09	Liban-Nord	Liban-Nord	278297
-LB.06	Liban-Sud	Liban-Sud	279894
+LB.06	South Governorate	South Governorate	279894
 LB.08	Béqaa	Beqaa	280282
 LB.07	Nabatîyé	Nabatiye	444191
 LB.10	Aakkâr	Aakkar	6201370
 LB.11	Baalbek-Hermel	Baalbek-Hermel	6201371
 LC.10	Vieux-Fort	Vieux-Fort	3576413
 LC.09	Soufrière	Soufriere	3576441
-LC.11	Praslin	Praslin	3576507
-LC.08	Micoud Quarter	Micoud Quarter	3576567
-LC.07	Laborie Quarter	Laborie Quarter	3576662
+LC.08	Micoud	Micoud	3576567
+LC.07	Laborie	Laborie	3576662
 LC.06	Gros-Islet	Gros-Islet	3576685
-LC.05	Dennery Quarter	Dennery Quarter	3576764
-LC.02	Dauphin	Dauphin	3576771
-LC.04	Choiseul Quarter	Choiseul Quarter	3576794
-LC.03	Castries Quarter	Castries Quarter	3576810
+LC.05	Dennery	Dennery	3576764
+LC.04	Choiseul	Choiseul	3576794
+LC.03	Castries	Castries	3576810
 LC.01	Anse-la-Raye	Anse-la-Raye	3576891
+LC.12	Canaries	Canaries	11351387
 LI.11	Vaduz	Vaduz	3042031
 LI.10	Triesenberg	Triesenberg	3042034
 LI.09	Triesen	Triesen	3042036
@@ -1710,138 +1777,71 @@ LS.13	Mafeteng	Mafeteng	932615
 LS.12	Leribe	Leribe	932700
 LS.11	Butha-Buthe	Butha-Buthe	932888
 LS.10	Berea	Berea	932932
-LT.56	Alytaus apskritis	Alytaus apskritis	864389
-LT.57	Kauno apskritis	Kauno apskritis	864477
-LT.58	Klaipėdos apskritis	Klaipedos apskritis	864478
-LT.59	Marijampolės apskritis	Marijampoles apskritis	864479
+LT.56	Alytus	Alytus	864389
+LT.57	Kaunas	Kaunas	864477
+LT.58	Klaipėda County	Klaipeda County	864478
+LT.59	Marijampolė County	Marijampole County	864479
 LT.60	Panevėžys	Panevezys	864480
-LT.61	Šiaulių apskritis	Siauliu apskritis	864481
-LT.62	Tauragės apskritis	Taurages apskritis	864482
-LT.63	Telšių apskritis	Telsiu apskritis	864483
-LT.64	Utenos apskritis	Utenos apskritis	864484
-LT.65	Vilnius County	Vilnius County	864485
-LU.03	Luxembourg	Luxembourg	2960314
-LU.02	Grevenmacher	Grevenmacher	2960513
-LU.01	Diekirch	Diekirch	2960655
+LT.61	Siauliai	Siauliai	864481
+LT.62	Tauragė County	Taurage County	864482
+LT.63	Telsiai	Telsiai	864483
+LT.64	Utena	Utena	864484
+LT.65	Vilnius	Vilnius	864485
+LU.WI	Wiltz	Wiltz	2959975
+LU.VD	Vianden	Vianden	2960020
+LU.RM	Remich	Remich	2960152
+LU.RD	Redange	Redange	2960161
+LU.ME	Mersch	Mersch	2960275
+LU.LU	Luxembourg	Luxembourg	2960315
+LU.GR	Grevenmacher	Grevenmacher	2960514
+LU.ES	Esch-sur-Alzette	Esch-sur-Alzette	2960599
+LU.EC	Echternach	Echternach	2960629
+LU.DI	Diekirch	Diekirch	2960656
+LU.CL	Clervaux	Clervaux	2960683
+LU.CA	Capellen	Capellen	2960696
 LV.33	Ventspils Rajons	Ventspils Rajons	454307
 LV.32	Ventspils	Ventspils	454311
-LV.31	Valmieras Rajons	Valmieras Rajons	454564
-LV.30	Valkas Rajons	Valkas Rajons	454571
-LV.29	Tukuma Rajons	Tukuma Rajons	454771
-LV.28	Talsu Rajons	Talsu Rajons	454968
+LV.31	Valmiera	Valmiera	454564
+LV.30	Valka	Valka	454571
+LV.29	Tukums Municipality	Tukums Municipality	454771
+LV.28	Talsi Municipality	Talsi Municipality	454968
 LV.27	Saldus Rajons	Saldus Rajons	455888
 LV.25	Riga	Riga	456173
-LV.24	Rēzeknes Rajons	Rezeknes Rajons	456197
+LV.24	Rēzekne Municipality	Rezekne Municipality	456197
 LV.23	Rēzekne	Rezekne	456203
-LV.22	Preiļu Rajons	Preilu Rajons	456528
+LV.22	Preiļu novads	Preilu novads	456528
 LV.21	Ogre	Ogre	457061
-LV.20	Madonas Rajons	Madonas Rajons	457712
-LV.19	Ludzas Rajons	Ludzas Rajons	457773
-LV.18	Limbažu Rajons	Limbazu Rajons	457889
+LV.20	Madona Municipality	Madona Municipality	457712
+LV.19	Ludza Municipality	Ludza Municipality	457773
+LV.18	Limbaži Municipality	Limbazi Municipality	457889
 LV.16	Liepāja	Liepaja	457955
-LV.15	Kuldīgas Rajons	Kuldigas Rajons	458459
-LV.14	Krāslavas Rajons	Kraslavas Rajons	458621
+LV.15	Kuldīga Municipality	Kuldiga Municipality	458459
+LV.14	Krāslava Municipality	Kraslava Municipality	458621
 LV.13	Jūrmala	Jurmala	459202
-LV.12	Jelgavas Rajons	Jelgavas Rajons	459278
+LV.12	Jelgava Municipality	Jelgava Municipality	459278
 LV.11	Jelgava	Jelgava	459281
-LV.10	Jēkabpils Rajons	Jekabpils Rajons	459282
-LV.09	Gulbenes Rajons	Gulbenes Rajons	459664
-LV.08	Dobeles Rajons	Dobeles Rajons	460311
-LV.07	Daugavpils	Daugavpils	460410
+LV.10	Jēkabpils Municipality	Jekabpils Municipality	459282
+LV.09	Gulbene Municipality	Gulbene Municipality	459664
+LV.08	Dobele Municipality	Dobele Municipality	460311
 LV.06	Daugavpils	Daugavpils	460414
-LV.05	Cēsu Rajons	Cesu Rajons	460569
-LV.04	Bauskas Rajons	Bauskas Rajons	461112
-LV.03	Balvu Rajons	Balvu Rajons	461160
-LV.02	Alūksnes Rajons	Aluksnes Rajons	461525
-LV.01	Aizkraukles Rajons	Aizkraukles Rajons	461613
-LV.60	Dundaga	Dundaga	7628298
-LV.40	Alsunga	Alsunga	7628299
-LV.A5	Pāvilostas	Pavilostas	7628300
-LV.99	Nīca	Nica	7628301
-LV.B6	Rucavas	Rucavas	7628302
-LV.65	Grobiņa	Grobina	7628303
-LV.61	Durbe	Durbe	7628304
-LV.37	Aizpute	Aizpute	7628305
-LV.A8	Priekule	Priekule	7628306
-LV.D7	Vaiņode	Vainode	7628307
-LV.C9	Skrunda	Skrunda	7628308
-LV.51	Brocēni	Broceni	7628309
-LV.B4	Rojas	Rojas	7628310
-LV.77	Kandava	Kandava	7628311
-LV.44	Auces Novads	Auces Novads	7628312
-LV.73	Jaunpils	Jaunpils	7628313
-LV.62	Engure	Engure	7628314
-LV.D5	Tērvete	Tervete	7628315
-LV.A3	Ozolnieku	Ozolnieku	7628316
-LV.B9	Rundāles	Rundales	7628317
-LV.45	Babīte	Babite	7628318
+LV.05	Cēsis Municipality	Cesis Municipality	460569
+LV.04	Bauska Municipality	Bauska Municipality	461112
+LV.03	Balvi Municipality	Balvi Municipality	461160
+LV.02	Alūksne Municipality	Aluksne Municipality	461525
+LV.01	Aizkraukle Municipality	Aizkraukle Municipality	461613
 LV.95	Mārupe	Marupe	7628319
 LV.A2	Olaine	Olaine	7628320
-LV.67	Lecava	Lecava	7628321
 LV.80	Ķekava	Kekava	7628322
-LV.C3	Salaspils	Salaspils	7628323
-LV.46	Baldone	Baldone	7628324
-LV.D2	Stopiņi	Stopini	7628325
-LV.53	Carnikava	Carnikava	7628326
+LV.C3	Salaspils Municipality	Salaspils Municipality	7628323
 LV.34	Ādaži	Adazi	7628327
-LV.64	Garkalne	Garkalne	7628328
-LV.E4	Vecumnieki	Vecumnieki	7628329
-LV.79	Ķegums	Kegums	7628330
-LV.87	Lielvārde	Lielvarde	7628331
-LV.C8	Skrīveri	Skriveri	7628332
-LV.71	Jaunjelgava	Jaunjelgava	7628333
-LV.98	Nereta	Nereta	7628334
-LV.E6	Viesīte	Viesite	7628335
-LV.C2	Salas	Salas	7628336
-LV.74	Jēkabpils	Jekabpils	7628337
-LV.38	Aknīste	Akniste	7628338
-LV.69	Ilūkste	Ilukste	7628339
-LV.E2	Vārkava	Varkava	7628340
 LV.90	Līvāni	Livani	7628341
-LV.E1	Varakļāni	Varaklani	7628342
-LV.E8	Vilanu	Vilanu	7628343
-LV.B3	Riebiņu	Riebinu	7628344
-LV.35	Aglona	Aglona	7628345
-LV.56	Cibla	Cibla	7628346
-LV.E9	Zilupes	Zilupes	7628347
-LV.E7	Viļaka	Vilaka	7628348
-LV.47	Baltinava	Baltinava	7628349
-LV.57	Dagda	Dagda	7628350
-LV.78	Karsava	Karsava	7628351
-LV.B7	Rugāju	Rugaju	7628352
-LV.55	Cesvaine	Cesvaine	7628353
-LV.91	Lubāna	Lubana	7628354
-LV.85	Krustpils	Krustpils	7628355
-LV.A6	Pļaviņu	Plavinu	7628356
-LV.82	Koknese	Koknese	7628357
-LV.68	Ikšķile	Ikskile	7628358
-LV.B5	Ropažu	Ropazu	7628359
-LV.70	Inčukalns	Incukalns	7628360
-LV.84	Krimulda	Krimulda	7628361
-LV.C7	Sigulda	Sigulda	7628362
-LV.88	Līgatne	Ligatne	7628363
-LV.94	Mālpils	Malpils	7628364
-LV.C6	Sēja	Seja	7628365
-LV.C5	Saulkrastu	Saulkrastu	7628366
-LV.C1	Salacgrīvas	Salacgrivas	7628367
-LV.39	Aloja	Aloja	7628368
-LV.97	Naukšēni	Naukseni	7628369
-LV.B8	Rūjienas	Rujienas	7628370
-LV.96	Mazsalaca	Mazsalaca	7628371
-LV.52	Burtnieki	Burtnieki	7628372
-LV.A4	Pārgaujas	Pargaujas	7628373
-LV.81	Kocēni	Koceni	7628374
-LV.42	Amatas Novads	Amatas Novads	7628375
-LV.A9	Priekuļi	Priekuli	7628376
-LV.B1	Raunas	Raunas	7628377
-LV.D3	Strenči	Strenci	7628378
-LV.50	Beverīna	Beverina	7628379
-LV.D1	Smiltene	Smiltene	7628380
-LV.72	Jaunpiebalga	Jaunpiebalga	7628381
-LV.63	Ērgļi	Ergli	7628382
-LV.E3	Vecpiebalga	Vecpiebalga	7628383
-LV.43	Apes Novads	Apes Novads	7628384
-LV.F1	Mesraga	Mesraga	8299767
+LV.E1	Varakļāni Municipality	Varaklani Municipality	7628342
+LV.B5	Ropaži Municipality	Ropazi Municipality	7628359
+LV.C7	Sigulda Municipality	Sigulda Municipality	7628362
+LV.C5	Saulkrasti Municipality	Saulkrasti Municipality	7628366
+LV.D1	Smiltene Municipality	Smiltene Municipality	7628380
+LV.DN	South Kurzeme Municipality	South Kurzeme Municipality	12276857
+LV.AN	Augšdaugava Municipality	Augsdaugava Municipality	12276858
 LY.70	Darnah	Darnah	87204
 LY.69	Banghāzī	Banghazi	88318
 LY.66	Al Marj	Al Marj	88904
@@ -1850,37 +1850,33 @@ LY.63	Al Jabal al Akhḑar	Al Jabal al Akhdar	443289
 LY.77	Tripoli	Tripoli	2210245
 LY.76	Surt	Surt	2210553
 LY.75	Sabhā	Sabha	2212774
-LY.74	Sha‘bīyat Nālūt	Sha`biyat Nalut	2214432
+LY.74	Nālūt	Nalut	2214432
 LY.73	Murzuq	Murzuq	2214602
 LY.72	Mişrātah	Misratah	2214845
-LY.71	Sha‘bīyat Ghāt	Sha`biyat Ghat	2217350
+LY.71	Ghāt	Ghat	2217350
 LY.68	Az Zāwiyah	Az Zawiyah	2218972
-LY.78	Ash Shāţiʼ	Sha`biyat Wadi ash Shati'	2219413
+LY.78	Ash Shāţiʼ	Wadi ash Shati'	2219413
 LY.64	Al Jufrah	Al Jufrah	2219944
 LY.67	An Nuqāţ al Khams	An Nuqat al Khams	2593778
-LY.79	Sha‘bīyat al Buţnān	Sha`biyat al Butnan	7602688
-LY.80	Sha‘bīyat al Jabal al Gharbī	Sha`biyat al Jabal al Gharbi	7602689
-LY.81	Sha‘bīyat al Jafārah	Sha`biyat al Jafarah	7602690
+LY.79	Al Buţnān	Al Butnan	7602688
+LY.80	Jabal al Gharbi	Jabal al Gharbi	7602689
+LY.81	Al Jafārah	Al Jafarah	7602690
 LY.82	Al Marqab	Al Marqab	7602691
-LY.83	Sha‘bīyat al Wāḩāt	Sha`biyat al Wahat	7602692
-LY.84	Sha‘bīyat Wādī al Ḩayāt	Sha`biyat Wadi al Hayat	7602693
-MA.49	Rabat-Salé-Zemmour-Zaër	Rabat-Sale-Zemmour-Zaer	2538470
-MA.48	Meknès-Tafilalet	Meknes-Tafilalet	2542710
-MA.47	Marrakech-Tensift-Al Haouz	Marrakech-Tensift-Al Haouz	2542995
-MA.46	Fès-Boulemane	Fes-Boulemane	2548882
-MA.45	Grand Casablanca	Grand Casablanca	2553603
-MA.50	Chaouia-Ouardigha	Chaouia-Ouardigha	2597548
-MA.51	Doukkala-Abda	Doukkala-Abda	2597549
-MA.52	Gharb-Chrarda-Beni Hssen	Gharb-Chrarda-Beni Hssen	2597550
-MA.53	Guelmim-Es Smara	Guelmim-Es Smara	2597551
-MA.54	Oriental	Oriental	2597553
-MA.55	Souss-Massa-Drâa	Souss-Massa-Draa	2597554
-MA.56	Tadla-Azilal	Tadla-Azilal	2597555
-MA.57	Tanger-Tétouan	Tanger-Tetouan	2597556
-MA.58	Taza-Al Hoceima-Taounate	Taza-Al Hoceima-Taounate	2597557
-MA.59	Laâyoune-Boujdour-Sakia El Hamra	Laayoune-Boujdour-Sakia El Hamra	6545402
-MA.EH	Oued ed Dahab-Lagouira	Oued ed Dahab-Lagouira	7627603
-MC.00		Commune de Monaco	3319178
+LY.83	Al Wāḩāt	Al Wahat	7602692
+LY.84	Wādī al Ḩayāt	Wadi al Hayat	7602693
+MA.01	Tanger-Tetouan-Al Hoceima	Tanger-Tetouan-Al Hoceima	11281874
+MA.02	Oriental	Oriental	11281875
+MA.03	Fès-Meknès	Fes-Meknes	11281876
+MA.04	Rabat-Salé-Kénitra	Rabat-Sale-Kenitra	11281877
+MA.05	Béni Mellal-Khénifra	Beni Mellal-Khenifra	11281878
+MA.06	Casablanca-Settat	Casablanca-Settat	11281879
+MA.07	Marrakesh-Safi	Marrakesh-Safi	11281880
+MA.08	Drâa-Tafilalet	Draa-Tafilalet	11281881
+MA.09	Souss-Massa	Souss-Massa	11281882
+MA.10	Guelmim-Oued Noun	Guelmim-Oued Noun	11281884
+MA.11	Laâyoune-Sakia El Hamra	Laayoune-Sakia El Hamra	11281885
+MA.12	Dakhla-Oued Ed-Dahab	Dakhla-Oued Ed-Dahab	11281886
+MC.00	Municipality of Monaco	Municipality of Monaco	3319178
 MD.73	Raionul Edineţ	Raionul Edinet	617077
 MD.92	Ungheni	Ungheni	617181
 MD.91	Teleneşti	Telenesti	617255
@@ -1897,15 +1893,15 @@ MD.80	Nisporeni	Nisporeni	617754
 MD.79	Leova	Leova	617903
 MD.85	Sîngerei	Singerei	617913
 MD.69	Criuleni	Criuleni	617962
-MD.78	Laloveni	Laloveni	617991
-MD.57	Chişinău	Chisinau	618069
+MD.78	Ialoveni	Ialoveni	617991
+MD.57	Chișinău Municipality	Chisinau Municipality	618069
 MD.67	Căuşeni	Causeni	618119
 MD.65	Cantemir	Cantemir	618142
 MD.66	Călăraşi	Calarasi	618162
 MD.64	Cahul	Cahul	618164
 MD.76	Glodeni	Glodeni	618260
 MD.75	Floreşti	Floresti	618331
-MD.74	Făleşti	Falesti	618345
+MD.74	Fălești	Falesti	618345
 MD.72	Dubăsari	Dubasari	618363
 MD.71	Drochia	Drochia	618369
 MD.70	Donduşeni	Donduseni	618381
@@ -1914,11 +1910,11 @@ MD.63	Briceni	Briceni	618511
 MD.61	Basarabeasca	Basarabeasca	618565
 MD.77	Hînceşti	Hincesti	858803
 MD.86	Şoldăneşti	Soldanesti	858808
-MD.58	Stînga Nistrului	Stinga Nistrului	858889
+MD.58	Transnistria	Transnistria	858889
 MD.51	Găgăuzia	Gagauzia	858895
-MD.62	Bender	Bender	861487
+MD.62	Bender Municipality	Bender Municipality	861487
 MD.60	Bălţi	Balti	873909
-ME.17	Opština Rožaje	Opstina Rozaje	786233
+ME.17	Rožaje Municipality	Rozaje Municipality	786233
 ME.21	Opština Žabljak	Opstina Zabljak	3186995
 ME.20	Ulcinj	Ulcinj	3188514
 ME.19	Tivat	Tivat	3189071
@@ -1939,28 +1935,32 @@ ME.05	Budva	Budva	3203104
 ME.04	Bijelo Polje	Bijelo Polje	3204173
 ME.02	Bar	Bar	3204508
 ME.01	Andrijevica	Andrijevica	3343959
-MG.7670842	Diana	Diana	7670842
-MG.7670846	Sava	Sava	7670846
-MG.7670847	Sofia	Sofia	7670847
-MG.7670848	Analanjirofo	Analanjirofo	7670848
-MG.7670849	Boeny	Boeny	7670849
-MG.7670850	Betsiboka	Betsiboka	7670850
-MG.7670851	Alaotra Mangoro	Alaotra Mangoro	7670851
-MG.7670852	Melaky	Melaky	7670852
-MG.7670853	Bongolava	Bongolava	7670853
-MG.7670854	Vakinankaratra	Vakinankaratra	7670854
-MG.7670855	Itasy	Itasy	7670855
-MG.7670856	Analamanga	Analamanga	7670856
-MG.7670857	Atsinanana	Atsinanana	7670857
-MG.7670902	Menabe	Menabe	7670902
-MG.7670904	Amoron'i Mania	Amoron'i Mania	7670904
-MG.7670905	Upper Matsiatra	Upper Matsiatra	7670905
-MG.7670906	Vatovavy Fitovinany	Vatovavy Fitovinany	7670906
-MG.7670907	Ihorombe	Ihorombe	7670907
-MG.7670908	Atsimo-Atsinanana	Atsimo-Atsinanana	7670908
-MG.7670910	Anosy	Anosy	7670910
-MG.7670911	Androy	Androy	7670911
-MG.7670913	Atsimo-Andrefana	Atsimo-Andrefana	7670913
+ME.22	Gusinje	Gusinje	11497642
+ME.23	Petnjica	Petnjica	11497643
+ME.24	Tuzi	Tuzi	12104729
+MG.71	Diana	Diana	7670842
+MG.72	Sava	Sava	7670846
+MG.42	Sofia	Sofia	7670847
+MG.32	Analanjirofo	Analanjirofo	7670848
+MG.41	Boeny	Boeny	7670849
+MG.43	Betsiboka	Betsiboka	7670850
+MG.33	Alaotra Mangoro	Alaotra Mangoro	7670851
+MG.44	Melaky	Melaky	7670852
+MG.14	Bongolava	Bongolava	7670853
+MG.12	Vakinankaratra	Vakinankaratra	7670854
+MG.13	Itasy	Itasy	7670855
+MG.11	Analamanga	Analamanga	7670856
+MG.31	Atsinanana	Atsinanana	7670857
+MG.54	Menabe	Menabe	7670902
+MG.22	Amoron'i Mania	Amoron'i Mania	7670904
+MG.21	Upper Matsiatra	Upper Matsiatra	7670905
+MG.24	Ihorombe	Ihorombe	7670907
+MG.25	Atsimo-Atsinanana	Atsimo-Atsinanana	7670908
+MG.53	Anosy	Anosy	7670910
+MG.52	Androy	Androy	7670911
+MG.51	Atsimo-Andrefana	Atsimo-Andrefana	7670913
+MG.26	Fitovinany Region	Fitovinany Region	12494965
+MG.27	Vatovavy Region	Vatovavy Region	12494968
 MH.007	Ailinginae Atoll	Ailinginae Atoll	7303491
 MH.010	Ailinglaplap Atoll	Ailinglaplap Atoll	7303492
 MH.030	Ailuk Atoll	Ailuk Atoll	7303493
@@ -1997,13 +1997,13 @@ MH.310	Mejit Island	Mejit Island	7303523
 MK.E9	Valandovo	Valandovo	784732
 MK.86	Resen	Resen	786339
 MK.51	Kratovo	Kratovo	789090
-MK.78	Pehčevo	Pehcevo	862938
+MK.78	Pehchevo	Pehchevo	862938
 MK.72	Novo Selo	Novo Selo	862945
 MK.11	Bosilovo	Bosilovo	862946
 MK.A9	Vasilevo	Vasilevo	862947
 MK.E5	Dojran	Dojran	862949
 MK.08	Bogdanci	Bogdanci	862950
-MK.47	Konče	Konce	862953
+MK.47	Konche	Konche	862953
 MK.62	Makedonska Kamenica	Makedonska Kamenica	862956
 MK.C6	Zrnovci	Zrnovci	862958
 MK.40	Karbinci	Karbinci	862960
@@ -2016,68 +2016,55 @@ MK.E1	Novaci	Novaci	863468
 MK.04	Berovo	Berovo	863485
 MK.06	Bitola	Bitola	863486
 MK.D9	Mogila	Mogila	863488
-MK.01	Aračinovo	Aracinovo	863831
+MK.01	Arachinovo	Arachinovo	863831
 MK.C7	Bogovinje	Bogovinje	863834
 MK.12	Brvenica	Brvenica	863835
-MK.C8	Čair	Cair	863836
-MK.C9	Čaška	Caska	863838
-MK.D1	Centar	Centar	863840
-MK.18	Centar Župa	Centar Zupa	863841
-MK.20	Čučer-Sandevo	Cucer-Sandevo	863842
+MK.C9	Chashka	Chashka	863838
+MK.18	Centar Zhupa	Centar Zhupa	863841
+MK.20	Chucher Sandevo	Chucher Sandevo	863842
 MK.D2	Debar	Debar	863843
-MK.22	Delčevo	Delcevo	863844
+MK.22	Delchevo	Delchevo	863844
 MK.D3	Demir Hisar	Demir Hisar	863846
 MK.28	Dolneni	Dolneni	863849
-MK.29	Opstina Gjorce Petrov	Opstina Gjorce Petrov	863850
-MK.30	Drugovo	Drugovo	863851
-MK.32	Gazi Baba	Gazi Baba	863853
 MK.33	Gevgelija	Gevgelija	863854
 MK.D4	Gostivar	Gostivar	863855
 MK.36	Ilinden	Ilinden	863856
 MK.D5	Jegunovce	Jegunovce	863858
-MK.41	Karpoš	Karpos	863860
 MK.D6	Kavadarci	Kavadarci	863861
-MK.43	Kičevo	Kicevo	863862
-MK.44	Kisela Voda	Kisela Voda	863863
-MK.46	Kočani	Kocani	863865
+MK.43	Kichevo	Kichevo	863862
+MK.46	Kochani	Kochani	863865
 MK.52	Kriva Palanka	Kriva Palanka	863869
-MK.53	Krivogaštani	Krivogastani	863870
-MK.54	Kruševo	Krusevo	863871
+MK.53	Krivogashtani	Krivogashtani	863870
+MK.54	Krushevo	Krushevo	863871
 MK.D7	Kumanovo	Kumanovo	863873
-MK.59	Opstina Lipkovo	Opstina Lipkovo	863875
+MK.59	Lipkovo	Lipkovo	863875
 MK.D8	Makedonski Brod	Makedonski Brod	863877
 MK.69	Negotino	Negotino	863881
 MK.E2	Ohrid	Ohrid	863883
-MK.77	Oslomej	Oslomej	863885
 MK.79	Petrovec	Petrovec	863886
 MK.80	Plasnica	Plasnica	863887
 MK.E3	Prilep	Prilep	863888
-MK.83	Probištip	Probistip	863889
-MK.84	Radoviš	Radovis	863890
-MK.85	Opstina Rankovce	Opstina Rankovce	863891
-MK.E4	Opština Rostuša	Opstina Rostusa	863892
-MK.90	Saraj	Saraj	863894
+MK.83	Probishtip	Probishtip	863889
+MK.84	Radovish	Radovish	863890
+MK.85	Rankovce	Rankovce	863891
+MK.E4	Mavrovo and Rostuša	Mavrovo and Rostusa	863892
 MK.92	Sopište	Sopiste	863896
-MK.97	Staro Nagoričane	Staro Nagoricane	863899
-MK.98	Štip	Stip	863900
+MK.97	Staro Nagorichane	Staro Nagorichane	863899
+MK.98	Shtip	Shtip	863900
 MK.E6	Struga	Struga	863901
 MK.E7	Strumica	Strumica	863902
-MK.A2	Studeničani	Studenicani	863903
-MK.A3	Šuto Orizari	Suto Orizari	863904
+MK.A2	Studenichani	Studenichani	863903
 MK.A4	Sveti Nikole	Sveti Nikole	863905
 MK.A5	Tearce	Tearce	863906
 MK.E8	Tetovo	Tetovo	863907
 MK.F1	Veles	Veles	863909
-MK.B3	Vevčani	Vevcani	863911
+MK.B3	Vevchani	Vevchani	863911
 MK.B4	Vinica	Vinica	863912
-MK.B6	Vraneštica	Vranestica	863913
-MK.B7	Vrapčište	Vrapciste	863914
-MK.C1	Zajas	Zajas	863917
+MK.B7	Vrapchishte	Vrapchishte	863914
 MK.C2	Zelenikovo	Zelenikovo	863918
-MK.C3	Želino	Zelino	863919
-MK.F3	Aerodrom	Aerodrom	7056266
-MK.F4	Butel	Butel	7056269
+MK.C3	Zhelino	Zhelino	863919
 MK.F5	Debarca	Debarca	7056271
+MK.F6	Grad Skopje	Grad Skopje	11398357
 ML.08	Tombouctou	Tombouctou	2449066
 ML.06	Sikasso	Sikasso	2451184
 ML.05	Ségou	Segou	2451477
@@ -2087,6 +2074,8 @@ ML.03	Kayes	Kayes	2455517
 ML.09	Gao	Gao	2457161
 ML.01	Bamako	Bamako	2460594
 ML.10	Kidal	Kidal	2597449
+ML.12070575	Taoudénit	Taoudenit	12070575
+ML.12070577	Ménaka	Menaka	12070577
 MM.12	Tanintharyi	Tanintharyi	1293118
 MM.11	Shan	Shan	1297099
 MM.10	Sagain	Sagain	1298480
@@ -2101,9 +2090,10 @@ MM.05	Kayin	Kayin	1320233
 MM.04	Kachin	Kachin	1321702
 MM.03	Ayeyarwady	Ayeyarwady	1321850
 MM.02	Chin	Chin	1327132
-MN.19	Uvs	Uvs	1514967
+MM.18	Nay Pyi Taw	Nay Pyi Taw	8239588
+MN.19	Uvs Province	Uvs Province	1514967
 MN.12	Hovd	Hovd	1515696
-MN.10	Govĭ-Altay	Govi-Altay	1515917
+MN.10	Govi-Altai Province	Govi-Altai Province	1515917
 MN.09	Dzabkhan	Dzabkhan	1516012
 MN.03	Bayan-Ölgiy	Bayan-Olgiy	1516278
 MN.02	Bayanhongor	Bayanhongor	1516290
@@ -2113,18 +2103,24 @@ MN.17	Sühbaatar	Suhbaatar	2029155
 MN.16	Selenge	Selenge	2029432
 MN.15	Övörhangay	OEvoerhangay	2029546
 MN.14	Ömnögovĭ	OEmnoegovi	2029669
-MN.13	Hövsgöl	Hovsgol	2030469
+MN.13	Khövsgöl Province	Khoevsgoel Province	2030469
 MN.11	Hentiy	Hentiy	2030783
 MN.08	Middle Govĭ	Middle Govi	2031740
 MN.07	East Gobi Aymag	East Gobi Aymag	2031798
 MN.06	East Aimak	East Aimak	2031799
 MN.21	Bulgan	Bulgan	2032199
-MN.01	Arhangay	Arhangay	2032855
+MN.01	Arkhangai Province	Arkhangai Province	2032855
 MN.23	Darhan Uul	Darhan Uul	2055111
 MN.24	Govĭ-Sumber	Govi-Sumber	2055112
 MN.25	Orhon	Orhon	2055113
-MO.02	Macau	Macau	1821273
-MO.01	Ilhas	Ilhas	1821286
+MO.11875154	Nossa Senhora de Fátima	Nossa Senhora de Fatima	11875154
+MO.11875155	Santo António	Santo Antonio	11875155
+MO.11875156	São Lázaro	Sao Lazaro	11875156
+MO.11875157	Sé	Se	11875157
+MO.11875158	São Lourenço	Sao Lourenco	11875158
+MO.11875159	Nossa Senhora do Carmo	Nossa Senhora do Carmo	11875159
+MO.11875160	Cotai	Cotai	11875160
+MO.11875161	São Francisco Xavier	Sao Francisco Xavier	11875161
 MP.100	Rota	Rota	4041530
 MP.110	Saipan	Saipan	4041552
 MP.120	Tinian	Tinian	4041650
@@ -2133,16 +2129,18 @@ MQ.MQ	Martinique	Martinique	6690603
 MR.06	Trarza	Trarza	2375742
 MR.11	Tiris Zemmour	Tiris Zemmour	2375989
 MR.09	Tagant	Tagant	2376551
-MR.NKC	Nouakchott	Nouakchott	2377449
 MR.12	Inchiri	Inchiri	2378903
-MR.02	Hodh el Gharbi	Hodh el Gharbi	2379024
-MR.01	Hodh ech Chargui	Hodh ech Chargui	2379025
+MR.02	Hodh El Gharbi	Hodh El Gharbi	2379024
+MR.01	Hodh Ech Chargi	Hodh Ech Chargi	2379025
 MR.10	Guidimaka	Guidimaka	2379216
 MR.04	Gorgol	Gorgol	2379384
 MR.08	Dakhlet Nouadhibou	Dakhlet Nouadhibou	2380426
 MR.05	Brakna	Brakna	2380635
 MR.03	Assaba	Assaba	2381344
 MR.07	Adrar	Adrar	2381972
+MR.13	Nouakchott Ouest	Nouakchott Ouest	11496391
+MR.14	Nouakchott Nord	Nouakchott Nord	11496392
+MR.15	Nouakchott Sud	Nouakchott Sud	11496393
 MS.03	Saint Peter	Saint Peter	3578039
 MS.02	Saint Georges	Saint Georges	3578044
 MS.01	Saint Anthony	Saint Anthony	3578045
@@ -2154,7 +2152,7 @@ MT.05	Birżebbuġa	Birzebbuga	8299704
 MT.06	Bormla	Bormla	8299705
 MT.07	Dingli	Dingli	8299706
 MT.08	Il-Fgura	Il-Fgura	8299707
-MT.09	Il-Furjana	Il-Furjana	8299708
+MT.09	Floriana	Floriana	8299708
 MT.10	Il-Fontana	Il-Fontana	8299709
 MT.11	Għajnsielem	Ghajnsielem	8299710
 MT.12	L-Għarb	L-Gharb	8299711
@@ -2169,8 +2167,8 @@ MT.20	L-Imdina	L-Imdina	8299719
 MT.21	L-Imġarr	L-Imgarr	8299720
 MT.22	L-Imqabba	L-Imqabba	8299721
 MT.23	L-Imsida	L-Imsida	8299722
-MT.24	L-Imtarfa	L-Imtarfa	8299723
-MT.25	L-Isla	L-Isla	8299724
+MT.24	Mtarfa	Mtarfa	8299723
+MT.25	Senglea	Senglea	8299724
 MT.26	Il-Kalkara	Il-Kalkara	8299725
 MT.27	Ta’ Kerċem	Ta' Kercem	8299726
 MT.28	Kirkop	Kirkop	8299727
@@ -2213,7 +2211,7 @@ MT.65	Ħaż-Żebbuġ	Haz-Zebbug	8299763
 MT.66	Iż-Żebbuġ	Iz-Zebbug	8299764
 MT.67	Iż-Żejtun	Iz-Zejtun	8299765
 MT.68	Iż-Żurrieq	Iz-Zurrieq	8299766
-MT.60	Il-Belt Valletta	Il-Belt Valletta	8334638
+MT.60	Valletta	Valletta	8334638
 MU.21	Agalega Islands	Agalega Islands	448254
 MU.20	Savanne	Savanne	934017
 MU.19	Rivière du Rempart	Riviere du Rempart	934090
@@ -2234,25 +2232,19 @@ MV.44	Raa Atoll	Raa Atoll	1281918
 MV.43	Noonu Atoll	Noonu Atoll	1281937
 MV.42	Gnyaviyani Atoll	Gnyaviyani Atoll	1281945
 MV.41	Meemu Atholhu	Meemu Atholhu	1281985
-MV.39	Lhaviyani Atholhu	Lhaviyani Atholhu	1282096
+MV.39	Faadhippolhu Atoll	Faadhippolhu Atoll	1282096
 MV.05	Laamu	Laamu	1282101
 MV.38	Kaafu Atoll	Kaafu Atoll	1282208
 MV.37	Haa Dhaalu Atholhu	Haa Dhaalu Atholhu	1282293
 MV.36	Haa Alifu Atholhu	Haa Alifu Atholhu	1282294
-MV.35	Gaafu Dhaalu Atholhu	Gaafu Dhaalu Atholhu	1282328
-MV.34	Gaafu Alifu Atholhu	Gaafu Alifu Atholhu	1282329
+MV.35	Gaafu Dhaalu Atoll	Gaafu Dhaalu Atoll	1282328
+MV.34	Gaafu Alif Atoll	Gaafu Alif Atoll	1282329
 MV.33	Faafu Atholhu	Faafu Atholhu	1282393
 MV.32	Dhaalu Atholhu	Dhaalu Atholhu	1282447
 MV.31	Baa Atholhu	Baa Atholhu	1282478
 MV.30	Northern Ari Atoll	Northern Ari Atoll	1282497
-MV.40	Maale	Maale	1337624
-MV.48	South Province	South Province	8030589
-MV.49	Upper South	Upper South	8030590
-MV.50	Upper North	Upper North	8030591
-MV.51	Central Province	Central Province	8030592
-MV.52	South Central	South Central	8030593
-MV.53	North Central	North Central	8030594
-MV.54	North Province	North Province	8030595
+MV.40	Male	Male	1337624
+MV.10346475	Southern Ari Atoll	Southern Ari Atoll	10346475
 MW.S	Southern Region	Southern Region	923817
 MW.N	Northern Region	Northern Region	924591
 MW.C	Central Region	Central Region	931597
@@ -2309,7 +2301,7 @@ MZ.08	Tete	Tete	1026010
 MZ.05	Sofala	Sofala	1026804
 MZ.07	Niassa	Niassa	1030006
 MZ.06	Nampula	Nampula	1033354
-MZ.04	Maputo	Maputo	1040649
+MZ.04	Maputo Province	Maputo Province	1040649
 MZ.10	Manica	Manica	1040947
 MZ.03	Inhambane	Inhambane	1045110
 MZ.02	Gaza	Gaza	1046058
@@ -2359,7 +2351,7 @@ NG.26	Benue	Benue	2347266
 NG.46	Bauchi	Bauchi	2347468
 NG.25	Anambra	Anambra	2349961
 NG.21	Akwa Ibom	Akwa Ibom	2350813
-NG.11	Abuja Federal Capital Territory	Abuja Federal Capital Territory	2352776
+NG.11	FCT	FCT	2352776
 NG.45	Abia	Abia	2565340
 NG.36	Delta	Delta	2565341
 NG.35	Adamawa	Adamawa	2565342
@@ -2378,22 +2370,22 @@ NG.42	Osun	Osun	2597365
 NG.43	Taraba	Taraba	2597366
 NG.44	Yobe	Yobe	2597367
 NI.15	Rivas	Rivas	3617051
-NI.14	Río San Juan	Rio San Juan	3617056
-NI.13	Nueva Segovia	Nueva Segovia	3617458
-NI.12	Matagalpa	Matagalpa	3617707
-NI.11	Masaya	Masaya	3617722
-NI.10	Managua	Managua	3617762
-NI.09	Madriz	Madriz	3617796
-NI.08	León	Leon	3618029
-NI.07	Jinotega	Jinotega	3618928
-NI.06	Granada	Granada	3619135
-NI.05	Estelí	Esteli	3619193
-NI.04	Chontales	Chontales	3620368
+NI.14	Río San Juan Department	Rio San Juan Department	3617056
+NI.13	Nueva Segovia Department	Nueva Segovia Department	3617458
+NI.12	Matagalpa Department	Matagalpa Department	3617707
+NI.11	Masaya Department	Masaya Department	3617722
+NI.10	Managua Department	Managua Department	3617762
+NI.09	Madriz Department	Madriz Department	3617796
+NI.08	León Department	Leon Department	3618029
+NI.07	Jinotega Department	Jinotega Department	3618928
+NI.06	Granada Department	Granada Department	3619135
+NI.05	Estelí Department	Esteli Department	3619193
+NI.04	Chontales Department	Chontales Department	3620368
 NI.03	Chinandega	Chinandega	3620380
-NI.02	Carazo	Carazo	3620481
-NI.01	Boaco	Boaco	3620673
-NI.17	Atlántico Norte (RAAN)	Atlantico Norte (RAAN)	3830307
-NI.18	Atlántico Sur	Atlantico Sur	3830308
+NI.02	Carazo Department	Carazo Department	3620481
+NI.01	Boaco Department	Boaco Department	3620673
+NI.17	North Caribbean Coast	North Caribbean Coast	3830307
+NI.18	South Caribbean Coast	South Caribbean Coast	3830308
 NL.11	South Holland	South Holland	2743698
 NL.10	Zeeland	Zeeland	2744011
 NL.09	Utrecht	Utrecht	2745909
@@ -2406,30 +2398,24 @@ NL.03	Gelderland	Gelderland	2755634
 NL.02	Friesland	Friesland	2755812
 NL.01	Drenthe	Drenthe	2756631
 NL.16	Flevoland	Flevoland	3319179
-NO.05	Finnmark Fylke	Finnmark Fylke	780166
-NO.20	Vestfold	Vestfold	3132015
-NO.19	Vest-Agder	Vest-Agder	3132064
-NO.18	Troms	Troms	3133897
-NO.17	Telemark	Telemark	3134723
-NO.16	Sør-Trøndelag	Sor-Trondelag	3137400
-NO.15	Sogn og Fjordane	Sogn og Fjordane	3137966
 NO.14	Rogaland	Rogaland	3141558
-NO.13	Østfold	Ostfold	3143188
 NO.12	Oslo	Oslo	3143242
-NO.11	Oppland	Oppland	3143487
-NO.10	Nord-Trøndelag	Nord-Trondelag	3144148
 NO.09	Nordland	Nordland	3144301
 NO.08	Møre og Romsdal	More og Romsdal	3145495
-NO.07	Hordaland	Hordaland	3151864
-NO.06	Hedmark	Hedmark	3153403
-NO.04	Buskerud	Buskerud	3159665
-NO.02	Aust-Agder	Aust-Agder	3162354
-NO.01	Akershus	Akershus	3163480
-NP.FR	Far Western	Far Western	7289705
-NP.MR	Mid Western	Mid Western	7289706
-NP.CR	Central Region	Central Region	7289707
-NP.ER	Eastern Region	Eastern Region	7289708
-NP.WR	Western Region	Western Region	7289709
+NO.21	Trøndelag	Trondelag	11862827
+NO.30	Viken	Viken	12110595
+NO.42	Agder	Agder	12110596
+NO.54	Troms og Finnmark	Troms og Finnmark	12110597
+NO.34	Innlandet	Innlandet	12110598
+NO.38	Vestfold og Telemark	Vestfold og Telemark	12110599
+NO.46	Vestland	Vestland	12110600
+NP.1	Province 1	Province 1	12095447
+NP.2	Province 2	Province 2	12095448
+NP.3	Bagmati Province	Bagmati Province	12095449
+NP.4	Province 4	Province 4	12095450
+NP.5	Lumbini Province	Lumbini Province	12095451
+NP.6	Karnali Pradesh	Karnali Pradesh	12095452
+NP.7	Sudurpashchim Pradesh	Sudurpashchim Pradesh	12095453
 NR.14	Yaren	Yaren	2110418
 NR.13	Uaboe	Uaboe	2110420
 NR.12	Nibok	Nibok	2110423
@@ -2461,17 +2447,17 @@ NZ.10	Chatham Islands	Chatham Islands	4033013
 NZ.F5	Nelson	Nelson	6612108
 NZ.F7	Otago	Otago	6612109
 NZ.G3	West Coast	West Coast	6612113
-OM.01	Muḩāfaz̧at ad Dākhilīyah	Muhafazat ad Dakhiliyah	411735
-OM.02	Al Bāţinah	Al Batinah	411736
-OM.03	Al Wusţá	Al Wusta	411737
-OM.04	Ash Sharqīyah	Ash Sharqiyah	411738
-OM.09	Az̧ Z̧āhirah	Az Zahirah	411739
-OM.06	Muḩāfaz̧at Masqaţ	Muhafazat Masqat	411740
-OM.07	Musandam	Musandam	411741
-OM.08	Z̧ufār	Zufar	411742
+OM.01	Ad Dakhiliyah	Ad Dakhiliyah	411735
+OM.02	Al Batinah South	Al Batinah South	411736
+OM.03	Al Wusta Governorate	Al Wusta Governorate	411737
+OM.04	Southeastern Governorate	Southeastern Governorate	411738
+OM.09	Ad Dhahirah	Ad Dhahirah	411739
+OM.06	Muscat	Muscat	411740
+OM.07	Musandam Governorate	Musandam Governorate	411741
+OM.08	Dhofar	Dhofar	411742
 OM.10	Al Buraimi	Al Buraimi	7110710
-OM.12	Ash Sharqiyah	Ash Sharqiyah	8394433
-OM.11	Al Batinah	Al Batinah	8394434
+OM.12	Northeastern Governorate	Northeastern Governorate	8394433
+OM.11	Al Batinah North	Al Batinah North	8394434
 PA.10	Veraguas	Veraguas	3700159
 PA.09	Guna Yala	Guna Yala	3701537
 PA.08	Panamá	Panama	3703433
@@ -2480,10 +2466,12 @@ PA.06	Herrera	Herrera	3708710
 PA.05	Darién	Darien	3711671
 PA.04	Colón	Colon	3712073
 PA.03	Coclé	Cocle	3712162
-PA.02	Chiriquí	Chiriqui	3712410
-PA.01	Bocas del Toro	Bocas del Toro	3713954
+PA.02	Chiriquí Province	Chiriqui Province	3712410
+PA.01	Bocas del Toro Province	Bocas del Toro Province	3713954
 PA.11	Emberá	Embera	7303686
 PA.12	Ngöbe-Buglé	Ngoebe-Bugle	7303688
+PA.13	Panamá Oeste Province	Panama Oeste Province	11353126
+PA.NT	Naso Tjër Di	Naso Tjer Di	12508964
 PE.25	Ucayali	Ucayali	3691099
 PE.24	Tumbes	Tumbes	3691146
 PE.22	San Martín	San Martin	3692385
@@ -2501,8 +2489,8 @@ PE.19	Pasco	Pasco	3932834
 PE.18	Moquegua	Moquegua	3934607
 PE.17	Madre de Dios	Madre de Dios	3935619
 PE.LMA	Lima	Lima	3936451
-PE.15	Lima	Lima	3936452
-PE.12	Junín	Junin	3937485
+PE.15	Lima region	Lima region	3936452
+PE.12	Junin	Junin	3937485
 PE.11	Ica	Ica	3938526
 PE.09	Huancavelica	Huancavelica	3939467
 PE.08	Cusco	Cusco	3941583
@@ -2512,7 +2500,7 @@ PE.04	Arequipa	Arequipa	3947319
 PE.03	Apurímac	Apurimac	3947421
 PF.04	Îles Marquises	Iles Marquises	4019991
 PF.03	Îles Tuamotu-Gambier	Iles Tuamotu-Gambier	4030621
-PF.02	Îles Sous-le-Vent	Iles Sous-le-Vent	4034364
+PF.02	Leeward Islands	Leeward Islands	4034364
 PF.01	Îles du Vent	Iles du Vent	4034365
 PF.05	Îles Australes	Iles Australes	4034366
 PG.17	West New Britain	West New Britain	2083546
@@ -2554,29 +2542,28 @@ PH.09	Zamboanga Peninsula	Zamboanga Peninsula	7521308
 PH.11	Davao	Davao	7521309
 PH.05	Bicol	Bicol	7521310
 PH.NCR	Metro Manila	Metro Manila	7521311
-PK.08	Islāmābād	Islamabad	1162015
+PK.08	Islamabad	Islamabad	1162015
 PK.05	Sindh	Sindh	1164807
 PK.04	Punjab	Punjab	1167710
 PK.03	Khyber Pakhtunkhwa	Khyber Pakhtunkhwa	1168873
 PK.07	Gilgit-Baltistan	Gilgit-Baltistan	1168878
-PK.01	Federally Administered Tribal Areas	Federally Administered Tribal Areas	1179245
-PK.02	Balochistān	Balochistan	1183606
+PK.02	Balochistan	Balochistan	1183606
 PK.06	Azad Kashmir	Azad Kashmir	1184196
-PL.75	Lublin Voivodeship	Lublin Voivodeship	858785
-PL.77	Lesser Poland Voivodeship	Lesser Poland Voivodeship	858786
-PL.78	Masovian Voivodeship	Masovian Voivodeship	858787
-PL.80	Subcarpathian Voivodeship	Subcarpathian Voivodeship	858788
+PL.75	Lublin	Lublin	858785
+PL.77	Lesser Poland	Lesser Poland	858786
+PL.78	Mazovia	Mazovia	858787
+PL.80	Subcarpathia	Subcarpathia	858788
 PL.81	Podlasie	Podlasie	858789
 PL.84	Świętokrzyskie	Swietokrzyskie	858790
-PL.85	Warmian-Masurian Voivodeship	Warmian-Masurian Voivodeship	858791
-PL.72	Lower Silesian Voivodeship	Lower Silesian Voivodeship	3337492
+PL.85	Warmia-Masuria	Warmia-Masuria	858791
+PL.72	Lower Silesia	Lower Silesia	3337492
 PL.74	Łódź Voivodeship	Lodz Voivodeship	3337493
 PL.76	Lubusz	Lubusz	3337494
 PL.79	Opole Voivodeship	Opole Voivodeship	3337495
-PL.82	Pomeranian Voivodeship	Pomeranian Voivodeship	3337496
-PL.83	Silesian Voivodeship	Silesian Voivodeship	3337497
-PL.86	Greater Poland Voivodeship	Greater Poland Voivodeship	3337498
-PL.87	West Pomeranian Voivodeship	West Pomeranian Voivodeship	3337499
+PL.82	Pomerania	Pomerania	3337496
+PL.83	Silesia	Silesia	3337497
+PL.86	Greater Poland	Greater Poland	3337498
+PL.87	West Pomerania	West Pomerania	3337499
 PL.73	Kujawsko-Pomorskie	Kujawsko-Pomorskie	3337500
 PM.97502	Saint-Pierre	Saint-Pierre	3424935
 PM.97501	Miquelon-Langlade	Miquelon-Langlade	3424938
@@ -2594,21 +2581,21 @@ PR.021	Bayamón	Bayamon	4562837
 PR.023	Cabo Rojo	Cabo Rojo	4562997
 PR.025	Caguas	Caguas	4563011
 PR.027	Camuy	Camuy	4563065
-PR.029	Canovanas	Canovanas	4563169
+PR.029	Canóvanas	Canovanas	4563169
 PR.031	Carolina	Carolina	4563244
-PR.033	Catano	Catano	4563299
+PR.033	Cataño	Catano	4563299
 PR.035	Cayey	Cayey	4563309
 PR.037	Ceiba	Ceiba	4563380
 PR.039	Ciales	Ciales	4563774
 PR.041	Cidra	Cidra	4563778
 PR.043	Coamo	Coamo	4563812
-PR.045	Comerio	Comerio	4563921
+PR.045	Comerío	Comerio	4563921
 PR.047	Corozal	Corozal	4564004
 PR.049	Culebra	Culebra	4564071
 PR.051	Dorado	Dorado	4564134
 PR.053	Fajardo	Fajardo	4564949
 PR.054	Florida	Florida	4564993
-PR.055	Guanica	Guanica	4565091
+PR.055	Guánica	Guanica	4565091
 PR.057	Guayama	Guayama	4565107
 PR.059	Guayanilla	Guayanilla	4565112
 PR.061	Guaynabo	Guaynabo	4565120
@@ -2617,37 +2604,37 @@ PR.065	Hatillo	Hatillo	4565348
 PR.067	Hormigueros	Hormigueros	4565381
 PR.069	Humacao	Humacao	4565449
 PR.071	Isabela	Isabela	4565581
-PR.073	Municipio de Jayuya	Municipio de Jayuya	4565684
-PR.075	Juana Diaz	Juana Diaz	4565713
-PR.077	Municipio de Juncos	Municipio de Juncos	4565720
+PR.073	Jayuya	Jayuya	4565684
+PR.075	Juana Díaz	Juana Diaz	4565713
+PR.077	Juncos	Juncos	4565720
 PR.079	Lajas	Lajas	4565900
 PR.081	Lares	Lares	4565910
-PR.083	Las Marias	Las Marias	4565961
+PR.083	Las Marías	Las Marias	4565961
 PR.085	Las Piedras	Las Piedras	4565981
-PR.087	Loiza	Loiza	4566025
+PR.087	Loíza	Loiza	4566025
 PR.089	Luquillo	Luquillo	4566106
-PR.091	Manati	Manati	4566138
+PR.091	Manatí	Manati	4566138
 PR.093	Maricao	Maricao	4566180
 PR.095	Maunabo	Maunabo	4566209
-PR.097	Mayaguez	Mayaguez	4566217
+PR.097	Mayagüez	Mayagueez	4566217
 PR.099	Moca	Moca	4566272
 PR.101	Morovis	Morovis	4566334
 PR.103	Naguabo	Naguabo	4566397
 PR.105	Naranjito	Naranjito	4566403
 PR.107	Orocovis	Orocovis	4566456
 PR.109	Patillas	Patillas	4566654
-PR.111	Penuelas	Penuelas	4566689
+PR.111	Peñuelas	Penuelas	4566689
 PR.113	Ponce	Ponce	4566886
-PR.117	Rincon	Rincon	4567727
+PR.117	Rincón	Rincon	4567727
 PR.115	Quebradillas	Quebradillas	4567734
-PR.119	Rio Grande	Rio Grande	4567823
+PR.119	Río Grande	Rio Grande	4567823
 PR.121	Sabana Grande	Sabana Grande	4568015
 PR.123	Salinas	Salinas	4568043
-PR.125	San German	San German	4568105
+PR.125	San Germán	San German	4568105
 PR.127	San Juan	San Juan	4568138
 PR.129	San Lorenzo	San Lorenzo	4568150
-PR.131	San Sebastian	San Sebastian	4568177
-PR.133	Santa Isabel Municipio	Santa Isabel Municipio	4568213
+PR.131	San Sebastián	San Sebastian	4568177
+PR.133	Santa Isabel	Santa Isabel	4568213
 PR.135	Toa Alta	Toa Alta	4568404
 PR.137	Toa Baja	Toa Baja	4568408
 PR.139	Trujillo Alto	Trujillo Alto	4568452
@@ -2657,7 +2644,7 @@ PR.145	Vega Baja	Vega Baja	4568534
 PR.149	Villalba	Villalba	4568684
 PR.151	Yabucoa	Yabucoa	4568909
 PR.153	Yauco	Yauco	4568918
-PR.147	Vieques Municipality	Vieques Municipality	4568924
+PR.147	Vieques	Vieques	4568924
 PS.GZ	Gaza Strip	Gaza Strip	281132
 PS.WE	West Bank	West Bank	285153
 PT.19	Setúbal	Setubal	2262961
@@ -2715,18 +2702,19 @@ PY.23	Alto Paraguay	Alto Paraguay	3439441
 PY.22	Asunción	Asuncion	3474570
 PY.24	Boquerón	Boqueron	3867442
 QA.08	Madīnat ash Shamāl	Madinat ash Shamal	389462
-QA.04	Al Khawr	Al Khawr	389465
+QA.04	Al Khor	Al Khor	389465
 QA.09	Baladīyat Umm Şalāl	Baladiyat Umm Salal	389467
 QA.06	Baladīyat ar Rayyān	Baladiyat ar Rayyan	389469
 QA.01	Baladīyat ad Dawḩah	Baladiyat ad Dawhah	389470
 QA.10	Al Wakrah	Al Wakrah	389472
 QA.13	Baladīyat az̧ Z̧a‘āyin	Baladiyat az Za`ayin	8030540
+QA.14	Al-Shahaniya	Al-Shahaniya	11777514
 RE.RE	Réunion	Reunion	6690283
 RO.40	Vrancea	Vrancea	662447
 RO.39	Vâlcea	Valcea	662892
 RO.38	Vaslui	Vaslui	663116
 RO.37	Tulcea	Tulcea	664517
-RO.36	Timiş	Timis	665091
+RO.36	Timiș	Timis	665091
 RO.35	Teleorman	Teleorman	665283
 RO.34	Suceava	Suceava	665849
 RO.33	Sibiu	Sibiu	667267
@@ -2734,139 +2722,139 @@ RO.32	Satu Mare	Satu Mare	667869
 RO.31	Sălaj	Salaj	668248
 RO.30	Prahova	Prahova	669737
 RO.29	Olt	Olt	671857
-RO.28	Neamţ	Neamt	672460
-RO.27	Mureş	Mures	672628
+RO.28	Neamț	Neamt	672460
+RO.27	Mureș	Mures	672628
 RO.26	Mehedinți	Mehedinti	673612
 RO.25	Maramureş	Maramures	673887
-RO.23	Iaşi	Iasi	675809
-RO.22	Ialomiţa	Ialomita	675848
+RO.23	Iași	Iasi	675809
+RO.22	Ialomița	Ialomita	675848
 RO.21	Hunedoara	Hunedoara	675917
 RO.20	Harghita	Harghita	676309
 RO.19	Gorj	Gorj	676898
 RO.42	Giurgiu	Giurgiu	677104
-RO.18	Galaţi	Galati	677692
+RO.18	Galați	Galati	677692
 RO.17	Dolj	Dolj	679134
-RO.16	Dâmboviţa	Dambovita	679385
+RO.16	Dâmbovița	Dambovita	679385
 RO.15	Covasna	Covasna	680428
 RO.14	Constanța	Constanta	680962
 RO.13	Cluj	Cluj	681291
-RO.12	Caraş-Severin	Caras-Severin	682714
-RO.41	Călăraşi	Calarasi	683016
+RO.12	Caraș-Severin	Caras-Severin	682714
+RO.41	Călărași	Calarasi	683016
 RO.11	Buzău	Buzau	683121
-RO.10	Bucureşti	Bucuresti	683504
-RO.09	Braşov	Brasov	683843
+RO.10	București	Bucuresti	683504
+RO.09	Brașov	Brasov	683843
 RO.08	Brăila	Braila	683901
-RO.07	Botoşani	Botosani	684038
-RO.06	Bistriţa-Năsăud	Bistrita-Nasaud	684647
+RO.07	Botoșani	Botosani	684038
+RO.06	Bistrița-Năsăud	Bistrita-Nasaud	684647
 RO.05	Bihor	Bihor	684878
 RO.04	Bacău	Bacau	685947
-RO.03	Argeş	Arges	686192
+RO.03	Arges	Arges	686192
 RO.02	Arad	Arad	686253
 RO.01	Alba	Alba	686581
 RO.43	Ilfov	Ilfov	865518
-RS.VO	Autonomna Pokrajina Vojvodina	Autonomna Pokrajina Vojvodina	784272
+RS.VO	Vojvodina	Vojvodina	784272
 RS.SE	Central Serbia	Central Serbia	785958
-RU.88	Jaroslavl	Jaroslavl	468898
-RU.86	Voronezj	Voronezj	472039
-RU.85	Vologda	Vologda	472454
-RU.84	Volgograd	Volgograd	472755
+RU.88	Yaroslavl Oblast	Yaroslavl Oblast	468898
+RU.86	Voronezh Oblast	Voronezh Oblast	472039
+RU.85	Vologda Oblast	Vologda Oblast	472454
+RU.84	Volgograd Oblast	Volgograd Oblast	472755
 RU.81	Ulyanovsk	Ulyanovsk	479119
-RU.80	Udmurtiya	Udmurtiya	479613
-RU.77	Tverskaya	Tverskaya	480041
-RU.76	Tula	Tula	480508
-RU.73	Tatarstan	Tatarstan	484048
-RU.72	Tambov	Tambov	484638
-RU.70	Stavropol'skiy	Stavropol'skiy	487839
-RU.69	Smolensk	Smolensk	491684
-RU.67	Saratov	Saratov	498671
-RU.65	Samara	Samara	499068
-RU.62	Rjazan	Rjazan	500059
+RU.80	Udmurtiya Republic	Udmurtiya Republic	479613
+RU.77	Tver Oblast	Tver Oblast	480041
+RU.76	Tula Oblast	Tula Oblast	480508
+RU.73	Tatarstan Republic	Tatarstan Republic	484048
+RU.72	Tambov Oblast	Tambov Oblast	484638
+RU.70	Stavropol Kray	Stavropol Kray	487839
+RU.69	Smolensk Oblast	Smolensk Oblast	491684
+RU.67	Saratov Oblast	Saratov Oblast	498671
+RU.65	Samara Oblast	Samara Oblast	499068
+RU.62	Ryazan Oblast	Ryazan Oblast	500059
 RU.61	Rostov	Rostov	501165
-RU.60	Pskov	Pskov	504338
-RU.90	Perm	Perm	511180
-RU.57	Penza	Penza	511555
-RU.56	Orjol	Orjol	514801
-RU.55	Orenburg	Orenburg	515001
-RU.52	Novgorod	Novgorod	519324
-RU.68	North Ossetia	North Ossetia	519969
-RU.50	Nenetskiy Avtonomnyy Okrug	Nenetskiy Avtonomnyy Okrug	522652
+RU.60	Pskov Oblast	Pskov Oblast	504338
+RU.90	Perm Krai	Perm Krai	511180
+RU.57	Penza Oblast	Penza Oblast	511555
+RU.56	Oryol oblast	Oryol oblast	514801
+RU.55	Orenburg Oblast	Orenburg Oblast	515001
+RU.52	Novgorod Oblast	Novgorod Oblast	519324
+RU.68	North Ossetia–Alania	North Ossetia-Alania	519969
+RU.50	Nenets	Nenets	522652
 RU.49	Murmansk	Murmansk	524304
 RU.48	Moscow	Moscow	524894
-RU.47	Moskovskaya	Moskovskaya	524925
-RU.46	Mordoviya	Mordoviya	525369
-RU.45	Mariy-El	Mariy-El	529352
-RU.43	Lipetsk	Lipetsk	535120
-RU.42	Leningrad	Leningrad	536199
+RU.47	Moscow Oblast	Moscow Oblast	524925
+RU.46	Mordoviya Republic	Mordoviya Republic	525369
+RU.45	Mariy-El Republic	Mariy-El Republic	529352
+RU.43	Lipetsk Oblast	Lipetsk Oblast	535120
+RU.42	Leningradskaya Oblast'	Leningradskaya Oblast'	536199
 RU.66	St.-Petersburg	St.-Petersburg	536203
-RU.41	Kursk	Kursk	538555
-RU.38	Krasnodarskiy	Krasnodarskiy	542415
-RU.37	Kostroma	Kostroma	543871
-RU.34	Komi Republic	Komi Republic	545854
-RU.33	Kirov	Kirov	548389
-RU.28	Republic of Karelia	Republic of Karelia	552548
-RU.27	Karachayevo-Cherkesiya	Karachayevo-Cherkesiya	552927
-RU.25	Kaluga	Kaluga	553899
-RU.24	Kalmykiya	Kalmykiya	553972
-RU.23	Kaliningrad	Kaliningrad	554230
-RU.22	Kabardino-Balkariya	Kabardino-Balkariya	554667
-RU.21	Ivanovo	Ivanovo	555235
-RU.19	Ingushetiya	Ingushetiya	556349
-RU.51	Nizjnij Novgorod	Nizjnij Novgorod	559838
+RU.41	Kursk Oblast	Kursk Oblast	538555
+RU.38	Krasnodar Krai	Krasnodar Krai	542415
+RU.37	Kostroma Oblast	Kostroma Oblast	543871
+RU.34	Komi	Komi	545854
+RU.33	Kirov Oblast	Kirov Oblast	548389
+RU.28	Karelia	Karelia	552548
+RU.27	Karachayevo-Cherkesiya Republic	Karachayevo-Cherkesiya Republic	552927
+RU.25	Kaluga Oblast	Kaluga Oblast	553899
+RU.24	Kalmykiya Republic	Kalmykiya Republic	553972
+RU.23	Kaliningrad Oblast	Kaliningrad Oblast	554230
+RU.22	Kabardino-Balkariya Republic	Kabardino-Balkariya Republic	554667
+RU.21	Ivanovo Oblast	Ivanovo Oblast	555235
+RU.19	Ingushetiya Republic	Ingushetiya Republic	556349
+RU.51	Nizhny Novgorod Oblast	Nizhny Novgorod Oblast	559838
 RU.17	Dagestan	Dagestan	567293
 RU.16	Chuvashia	Chuvashia	567395
 RU.12	Chechnya	Chechnya	569665
-RU.10	Brjansk	Brjansk	571473
-RU.09	Belgorod	Belgorod	578071
-RU.08	Bashkortostan	Bashkortostan	578853
-RU.07	Astrakhan	Astrakhan	580491
+RU.10	Bryansk Oblast	Bryansk Oblast	571473
+RU.09	Belgorod Oblast	Belgorod Oblast	578071
+RU.08	Bashkortostan Republic	Bashkortostan Republic	578853
+RU.07	Astrakhan Oblast	Astrakhan Oblast	580491
 RU.06	Arkhangelskaya	Arkhangelskaya	581043
-RU.01	Adygeya	Adygeya	584222
-RU.83	Vladimir	Vladimir	826294
-RU.87	Yamalo-Nenetskiy Avtonomnyy Okrug	Yamalo-Nenetskiy Avtonomnyy Okrug	1486462
-RU.78	Tjumen	Tjumen	1488747
-RU.79	Tyva	Tyva	1488873
-RU.75	Tomsk	Tomsk	1489421
-RU.71	Sverdlovsk	Sverdlovsk	1490542
-RU.54	Omsk	Omsk	1496152
-RU.53	Novosibirsk	Novosibirsk	1496745
-RU.40	Kurgan	Kurgan	1501312
-RU.91	Krasnoyarskiy	Krasnoyarskiy	1502020
-RU.32	Khanty-Mansiyskiy Avtonomnyy Okrug	Khanty-Mansiyskiy Avtonomnyy Okrug	1503773
-RU.31	Khakasiya	Khakasiya	1503834
-RU.29	Kemerovo	Kemerovo	1503900
-RU.03	Altay	Altay	1506272
+RU.01	Adygeya Republic	Adygeya Republic	584222
+RU.83	Vladimir Oblast	Vladimir Oblast	826294
+RU.87	Yamalo-Nenets	Yamalo-Nenets	1486462
+RU.78	Tyumen Oblast	Tyumen Oblast	1488747
+RU.79	Republic of Tyva	Republic of Tyva	1488873
+RU.75	Tomsk Oblast	Tomsk Oblast	1489421
+RU.71	Sverdlovsk Oblast	Sverdlovsk Oblast	1490542
+RU.54	Omsk Oblast	Omsk Oblast	1496152
+RU.53	Novosibirsk Oblast	Novosibirsk Oblast	1496745
+RU.40	Kurgan Oblast	Kurgan Oblast	1501312
+RU.91	Krasnoyarsk Krai	Krasnoyarsk Krai	1502020
+RU.32	Khanty-Mansia	Khanty-Mansia	1503773
+RU.31	Khakasiya Republic	Khakasiya Republic	1503834
+RU.29	Kuzbass	Kuzbass	1503900
+RU.03	Altai	Altai	1506272
 RU.13	Chelyabinsk	Chelyabinsk	1508290
 RU.04	Altai Krai	Altai Krai	1511732
 RU.63	Sakha	Sakha	2013162
-RU.59	Primorskiy	Primorskiy	2017623
-RU.30	Khabarovsk Krai	Khabarovsk Krai	2022888
-RU.20	Irkutsk	Irkutsk	2023468
+RU.59	Primorye	Primorye	2017623
+RU.30	Khabarovsk	Khabarovsk	2022888
+RU.20	Irkutsk Oblast	Irkutsk Oblast	2023468
 RU.89	Jewish Autonomous Oblast	Jewish Autonomous Oblast	2026639
-RU.05	Amur	Amur	2027748
-RU.11	Respublika Buryatiya	Respublika Buryatiya	2050915
-RU.64	Sakhalin	Sakhalin	2121529
-RU.44	Magadan	Magadan	2123627
-RU.92	Kamtsjatka	Kamtsjatka	2125072
-RU.15	Chukotskiy Avtonomnyy Okrug	Chukotskiy Avtonomnyy Okrug	2126099
-RU.93	Transbaikal Territory	Transbaikal Territory	7779061
+RU.05	Amur Oblast	Amur Oblast	2027748
+RU.11	Buryatiya Republic	Buryatiya Republic	2050915
+RU.64	Sakhalin Oblast	Sakhalin Oblast	2121529
+RU.44	Magadan Oblast	Magadan Oblast	2123627
+RU.92	Kamchatka	Kamchatka	2125072
+RU.15	Chukotka	Chukotka	2126099
+RU.93	Zabaykalskiy (Transbaikal) Kray	Zabaykalskiy (Transbaikal) Kray	7779061
 RW.11	Eastern Province	Eastern Province	6413337
 RW.12	Kigali	Kigali	6413338
 RW.13	Northern Province	Northern Province	6413339
 RW.14	Western Province	Western Province	6413340
 RW.15	Southern Province	Southern Province	6413341
-SA.19	Minţaqat Tabūk	Mintaqat Tabuk	101627
-SA.16	Najrān	Najran	103628
-SA.14	Makkah	Makkah	104514
-SA.17	Jizan	Jizan	105298
-SA.13	Ḩāʼil	Mintaqat Ha'il	106280
-SA.11	Minţaqat ‘Asīr	Mintaqat `Asir	108179
+SA.19	Tabuk Region	Tabuk Region	101627
+SA.16	Najran Region	Najran Region	103628
+SA.14	Mecca Region	Mecca Region	104514
+SA.17	Jazan Region	Jazan Region	105298
+SA.13	Ha'il Region	Ha'il Region	106280
+SA.11	'Asir Region	'Asir Region	108179
 SA.06	Eastern Province	Eastern Province	108241
-SA.10	Ar Riyāḑ	Ar Riyad	108411
-SA.08	Al-Qassim	Al-Qassim	108933
-SA.05	Al Madīnah al Munawwarah	Al Madinah al Munawwarah	109224
-SA.20	Al Jawf	Al Jawf	109470
-SA.15	Northern Borders	Northern Borders	109579
-SA.02	Minţaqat al Bāḩah	Mintaqat al Bahah	109954
+SA.10	Riyadh Region	Riyadh Region	108411
+SA.08	Al-Qassim Region	Al-Qassim Region	108933
+SA.05	Medina Region	Medina Region	109224
+SA.20	Al Jawf Region	Al Jawf Region	109470
+SA.15	Northern Borders Region	Northern Borders Region	109579
+SA.02	Al Bahah Region	Al Bahah Region	109954
 SB.11	Western Province	Western Province	2101556
 SB.03	Malaita	Malaita	2106552
 SB.07	Isabel	Isabel	2108262
@@ -2885,7 +2873,7 @@ SC.19	Plaisance	Plaisance	241224
 SC.18	Mont Fleuri	Mont Fleuri	241251
 SC.17	Mont Buxton	Mont Buxton	241252
 SC.26	English River	English River	241302
-SC.25	Inner Islands	Inner Islands	241311
+SC.25	La Digue	La Digue	241311
 SC.24	Grand Anse Mahe	Grand Anse Mahe	241330
 SC.14	Grand Anse Praslin	Grand Anse Praslin	241331
 SC.12	Glacis	Glacis	241336
@@ -2902,6 +2890,9 @@ SC.01	Anse-aux-Pins	Anse-aux-Pins	241450
 SC.29	Les Mamelles	Les Mamelles	448408
 SC.30	Roche Caiman	Roche Caiman	448409
 SC.28	Au Cap	Au Cap	448410
+SC.11876017	Outer Islands	Outer Islands	11876017
+SC.12200079	Ile Perseverance I	Ile Perseverance I	12200079
+SC.12200080	Ile Perseverance II	Ile Perseverance II	12200080
 SD.43	Northern State	Northern State	378389
 SD.29	Khartoum	Khartoum	379253
 SD.36	Red Sea	Red Sea	408646
@@ -2910,12 +2901,13 @@ SD.39	Al Qaḑārif	Al Qadarif	408649
 SD.41	White Nile	White Nile	408653
 SD.42	Blue Nile	Blue Nile	408654
 SD.47	Western Darfur	Western Darfur	408658
+SD.62	West Kordofan State	West Kordofan State	408659
 SD.49	Southern Darfur	Southern Darfur	408660
 SD.50	Southern Kordofan	Southern Kordofan	408661
 SD.52	Kassala	Kassala	408663
 SD.53	River Nile	River Nile	408664
 SD.55	Northern Darfur	Northern Darfur	408666
-SD.56	Shamāl Kurdufān	Shamal Kurdufan	408667
+SD.56	North Kordofan	North Kordofan	408667
 SD.58	Sinnār	Sinnar	408669
 SD.60	Eastern Darfur	Eastern Darfur	8394435
 SD.61	Central Darfur	Central Darfur	8394436
@@ -2940,11 +2932,6 @@ SE.03	Gävleborg	Gaevleborg	2712411
 SE.02	Blekinge	Blekinge	2721357
 SE.27	Skåne	Skane	3337385
 SE.28	Västra Götaland	Vaestra Goetaland	3337386
-SG.01	Central Singapore	Central Singapore	7535954
-SG.02	North East	North East	7535955
-SG.04	South East	South East	7535956
-SG.05	South West	South West	7535957
-SG.03	North West	North West	7535958
 SH.01	Ascension	Ascension	2411430
 SH.03	Tristan da Cunha	Tristan da Cunha	3370684
 SH.02	Saint Helena	Saint Helena	6930057
@@ -2963,7 +2950,7 @@ SI.C2	Slovenj Gradec	Slovenj Gradec	3190535
 SI.B9	Škofja Loka	Skofja Loka	3190716
 SI.B7	Sežana	Sezana	3190944
 SI.B6	Sevnica	Sevnica	3190949
-SI.L7	Šentjur pri Celju	Sentjur pri Celju	3191028
+SI.L7	Sentjur	Sentjur	3191028
 SI.L1	Ribnica	Ribnica	3191679
 SI.A3	Radovljica	Radovljica	3192062
 SI.A2	Radlje ob Dravi	Radlje ob Dravi	3192120
@@ -3152,26 +3139,29 @@ SI.O9	Rečica ob Savinji	Recica ob Savinji	8133586
 SI.P1	Renče-Vogrsko	Rence-Vogrsko	8133587
 SI.P4	Središče ob Dravi	Sredisce ob Dravi	8133588
 SI.P5	Straža	Straza	8133589
-SI.P6	Sveta Trojica v Slovenskih Goricah	Sveta Trojica v Slovenskih Goricah	8133590
+SI.P6	Sv. Trojica v Slov. Goricah	Sv. Trojica v Slov. Goricah	8133590
 SI.P8	Sveti Tomaž	Sveti Tomaz	8133591
 SI.P2	Šentrupert	Sentrupert	8133592
 SI.P3	Šmarješke Toplice	Smarjeske Toplice	8133593
 SI.P7	Sveti Jurij v Slovenskih Goricah	Sveti Jurij v Slovenskih Goricah	8469236
 SI.O2	Gorje	Gorje	8986279
+SI.P9	Ankaran	Ankaran	11288217
+SI.O6	Mirna	Mirna	11288255
 SJ.22	Jan Mayen	Jan Mayen	3041964
 SJ.21	Svalbard	Svalbard	7521757
-SK.03	Košický	Kosicky	865084
-SK.05	Prešovský	Presovsky	865085
-SK.08	Žilinský	Zilinsky	3056506
-SK.01	Banskobystrický	Banskobystricky	3343954
-SK.02	Bratislavský	Bratislavsky	3343955
-SK.04	Nitriansky	Nitriansky	3343956
-SK.06	Trenčiansky	Trenciansky	3343957
-SK.07	Trnavský	Trnavsky	3343958
+SK.03	Košický kraj	Kosicky kraj	865084
+SK.05	Prešovský kraj	Presovsky kraj	865085
+SK.08	Žilinský kraj	Zilinsky kraj	3056506
+SK.01	Banskobystrický kraj	Banskobystricky kraj	3343954
+SK.02	Bratislavský Kraj	Bratislavsky Kraj	3343955
+SK.04	Nitriansky kraj	Nitriansky kraj	3343956
+SK.06	Trenčiansky kraj	Trenciansky kraj	3343957
+SK.07	Trnava	Trnava	3343958
 SL.04	Western Area	Western Area	2403068
 SL.03	Southern Province	Southern Province	2403745
 SL.02	Northern Province	Northern Province	2404798
 SL.01	Eastern Province	Eastern Province	2409543
+SL.05	North West	North West	11919533
 SM.09	Serravalle	Serravalle	3166650
 SM.02	Chiesanuova	Chiesanuova	3178807
 SM.07	San Marino	San Marino	3345302
@@ -3268,8 +3258,8 @@ SZ.03	Manzini	Manzini	934994
 SZ.02	Lubombo	Lubombo	935042
 SZ.01	Hhohho	Hhohho	935085
 TD.13	Salamat	Salamat	242048
-TD.12	Ouaddaï	Ouaddai	242246
-TD.02	Biltine	Biltine	244877
+TD.12	Ouadaï	Ouadai	242246
+TD.02	Wadi Fira	Wadi Fira	244877
 TD.14	Tandjilé	Tandjile	2425287
 TD.17	Moyen-Chari	Moyen-Chari	2427315
 TD.16	Mayo-Kebbi Est	Mayo-Kebbi Est	2428132
@@ -3284,7 +3274,7 @@ TD.23	Borkou	Borkou	7602866
 TD.18	Hadjer-Lamis	Hadjer-Lamis	7603251
 TD.19	Mandoul	Mandoul	7603252
 TD.20	Mayo-Kebbi Ouest	Mayo-Kebbi Ouest	7603253
-TD.21	Région de la Ville de N’Djaména	Region de la Ville de N'Djamena	7603254
+TD.21	N’Djaména	N'Djamena	7603254
 TD.22	Barh el Gazel	Barh el Gazel	7603255
 TD.25	Sila	Sila	7603257
 TD.26	Tibesti	Tibesti	7603258
@@ -3310,7 +3300,7 @@ TH.59	Ranong	Ranong	1150964
 TH.57	Prachuap Khiri Khan	Prachuap Khiri Khan	1151073
 TH.62	Phuket	Phuket	1151253
 TH.56	Phetchaburi	Phetchaburi	1151416
-TH.61	Phangnga	Phangnga	1151462
+TH.61	Phang Nga	Phang Nga	1151462
 TH.01	Mae Hong Son	Mae Hong Son	1152221
 TH.05	Lamphun	Lamphun	1152467
 TH.06	Lampang	Lampang	1152472
@@ -3325,12 +3315,12 @@ TH.70	Yala	Yala	1604869
 TH.10	Uttaradit	Uttaradit	1605214
 TH.49	Trat	Trat	1605277
 TH.29	Surin	Surin	1606029
-TH.51	Suphan Buri	Suphan Buri	1606032
+TH.51	Suphanburi	Suphanburi	1606032
 TH.68	Songkhla	Songkhla	1606146
-TH.30	Sisaket	Sisaket	1606238
+TH.30	Si Sa Ket	Si Sa Ket	1606238
 TH.33	Sing Buri	Sing Buri	1606269
 TH.67	Satun	Satun	1606375
-TH.37	Sara Buri	Sara Buri	1606417
+TH.37	Saraburi	Saraburi	1606417
 TH.54	Samut Songkhram	Samut Songkhram	1606585
 TH.55	Samut Sakhon	Samut Sakhon	1606587
 TH.42	Samut Prakan	Samut Prakan	1606589
@@ -3358,7 +3348,7 @@ TH.53	Nakhon Pathom	Nakhon Pathom	1608533
 TH.43	Nakhon Nayok	Nakhon Nayok	1608538
 TH.78	Mukdahan	Mukdahan	1608595
 TH.24	Maha Sarakham	Maha Sarakham	1608899
-TH.34	Lop Buri	Lop Buri	1609031
+TH.34	Lopburi	Lopburi	1609031
 TH.18	Loei	Loei	1609070
 TH.40	Bangkok	Bangkok	1609348
 TH.22	Khon Kaen	Khon Kaen	1609775
@@ -3370,18 +3360,18 @@ TH.32	Chai Nat	Chai Nat	1611415
 TH.44	Chachoengsao	Chachoengsao	1611438
 TH.28	Buriram	Buriram	1611452
 TH.35	Ang Thong	Ang Thong	1621034
-TH.76	Changwat Udon Thani	Changwat Udon Thani	1906686
+TH.76	Udon Thani	Udon Thani	1906686
 TH.74	Prachin Buri	Prachin Buri	1906687
-TH.75	Changwat Ubon Ratchathani	Changwat Ubon Ratchathani	1906688
+TH.75	Ubon Ratchathani	Ubon Ratchathani	1906688
 TH.77	Amnat Charoen	Amnat Charoen	1906689
-TH.79	Changwat Nong Bua Lamphu	Changwat Nong Bua Lamphu	1906690
+TH.79	Nong Bua Lam Phu	Nong Bua Lam Phu	1906690
 TH.80	Sa Kaeo	Sa Kaeo	1906691
-TH.81	Changwat Bueng Kan	Changwat Bueng Kan	8133594
-TJ.03	Viloyati Sughd	Viloyati Sughd	1221092
+TH.81	Bueng Kan	Bueng Kan	8133594
+TJ.03	Sughd	Sughd	1221092
 TJ.01	Gorno-Badakhshan	Gorno-Badakhshan	1221692
 TJ.02	Khatlon	Khatlon	1347488
 TJ.RR	Republican Subordination	Republican Subordination	6452615
-TJ.7280679	Dushanbe	Dushanbe	7280679
+TJ.04	Dushanbe	Dushanbe	7280679
 TK.N	Nukunonu	Nukunonu	4031091
 TK.F	Fakaofo	Fakaofo	4031112
 TK.A	Atafu	Atafu	4031116
@@ -3400,32 +3390,33 @@ TL.AN	Ainaro	Ainaro	1651809
 TL.AL	Aileu	Aileu	1651815
 TM.02	Balkan	Balkan	162152
 TM.01	Ahal	Ahal	162181
+TM.S	Ashgabat	Ashgabat	162182
 TM.03	Daşoguz	Dasoguz	601465
 TM.05	Mary	Mary	1218666
 TM.04	Lebap	Lebap	1219651
-TN.37	Zaghwān	Zaghwan	2464038
-TN.36	Tūnis	Tunis	2464464
-TN.35	Tawzar	Tawzar	2464645
+TN.37	Zaghouan Governorate	Zaghouan Governorate	2464038
+TN.36	Tunis Governorate	Tunis Governorate	2464464
+TN.35	Tozeur Governorate	Tozeur Governorate	2464645
 TN.34	Tataouine	Tataouine	2464698
-TN.23	Sūsah	Susah	2464912
-TN.22	Silyānah	Silyanah	2465027
-TN.33	Sīdī Bū Zayd	Sidi Bu Zayd	2465837
-TN.32	Şafāqis	Safaqis	2467450
-TN.31	Qibilī	Qibili	2468014
+TN.23	Sousse Governorate	Sousse Governorate	2464912
+TN.22	Siliana Governorate	Siliana Governorate	2465027
+TN.33	Sidi Bouzid Governorate	Sidi Bouzid Governorate	2465837
+TN.32	Sfax Governorate	Sfax Governorate	2467450
+TN.31	Kebili Governorate	Kebili Governorate	2468014
 TN.30	Gafsa	Gafsa	2468351
-TN.29	Qābis	Qabis	2468365
-TN.19	Nābul	Nabul	2468576
-TN.28	Madanīn	Madanin	2469470
-TN.06	Jundūbah	Jundubah	2470085
-TN.27	Bin ‘Arūs	Bin 'Arus	2472477
-TN.18	Banzart	Banzart	2472699
-TN.17	Bājah	Bajah	2472770
-TN.38	Ariana	Ariana	2473245
-TN.03	Al Qayrawān	Al Qayrawan	2473451
-TN.02	Al Qaşrayn	Al Qasrayn	2473460
-TN.16	Al Munastīr	Al Munastir	2473495
-TN.15	Al Mahdīyah	Al Mahdiyah	2473574
-TN.14	Kef	Kef	2473637
+TN.29	Gabès Governorate	Gabes Governorate	2468365
+TN.19	Nabeul Governorate	Nabeul Governorate	2468576
+TN.28	Medenine Governorate	Medenine Governorate	2469470
+TN.06	Jendouba Governorate	Jendouba Governorate	2470085
+TN.27	Ben Arous Governorate	Ben Arous Governorate	2472477
+TN.18	Bizerte Governorate	Bizerte Governorate	2472699
+TN.17	Béja Governorate	Beja Governorate	2472770
+TN.38	Ariana Governorate	Ariana Governorate	2473245
+TN.03	Kairouan	Kairouan	2473451
+TN.02	Kasserine Governorate	Kasserine Governorate	2473460
+TN.16	Monastir Governorate	Monastir Governorate	2473495
+TN.15	Mahdia Governorate	Mahdia Governorate	2473574
+TN.14	Kef Governorate	Kef Governorate	2473637
 TN.39	Manouba	Manouba	6201192
 TO.03	Vava‘u	Vava`u	4032231
 TO.02	Tongatapu	Tongatapu	4032279
@@ -3439,8 +3430,8 @@ TR.63	Şanlıurfa	Sanliurfa	298332
 TR.62	Tunceli	Tunceli	298845
 TR.58	Sivas	Sivas	300617
 TR.74	Siirt	Siirt	300821
-TR.73	Niğde	Nigde	303826
-TR.50	Nevşehir	Nevsehir	303830
+TR.73	Niğde Province	Nigde Province	303826
+TR.50	Nevşehir Province	Nevsehir Province	303830
 TR.49	Muş	Mus	304041
 TR.48	Muğla	Mugla	304183
 TR.72	Mardin	Mardin	304794
@@ -3451,7 +3442,7 @@ TR.71	Konya	Konya	306569
 TR.40	Kırşehir	Kirsehir	307513
 TR.38	Kayseri	Kayseri	308463
 TR.46	Kahramanmaraş	Kahramanmaras	310858
-TR.35	İzmir	Izmir	311044
+TR.35	İzmir Province	Izmir Province	311044
 TR.33	Isparta	Isparta	311071
 TR.32	Mersin	Mersin	311728
 TR.31	Hatay	Hatay	312394
@@ -3461,7 +3452,7 @@ TR.26	Eskişehir	Eskisehir	315201
 TR.25	Erzurum	Erzurum	315367
 TR.24	Erzincan	Erzincan	315372
 TR.23	Elazığ	Elazig	315807
-TR.21	Diyarbakır	Diyarbakir	316540
+TR.21	Diyarbakır Province	Diyarbakir Province	316540
 TR.20	Denizli	Denizli	317106
 TR.15	Burdur	Burdur	320390
 TR.13	Bitlis	Bitlis	321022
@@ -3472,8 +3463,8 @@ TR.09	Aydın	Aydin	322819
 TR.07	Antalya	Antalya	323776
 TR.68	Ankara	Ankara	323784
 TR.04	Ağrı	Agri	325163
-TR.03	Afyonkarahisar	Afyonkarahisar	325302
-TR.02	Adıyaman	Adiyaman	325329
+TR.03	Afyonkarahisar Province	Afyonkarahisar Province	325302
+TR.02	Adıyaman Province	Adiyaman Province	325329
 TR.81	Adana	Adana	325361
 TR.91	Osmaniye	Osmaniye	443183
 TR.88	Iğdır	Igdir	443184
@@ -3490,38 +3481,37 @@ TR.59	Tekirdağ	Tekirdag	738926
 TR.57	Sinop	Sinop	739598
 TR.55	Samsun	Samsun	740263
 TR.54	Sakarya	Sakarya	740352
-TR.53	Rize	Rize	740481
+TR.53	Rize Province	Rize Province	740481
 TR.52	Ordu	Ordu	741098
 TR.41	Kocaeli	Kocaeli	742865
 TR.39	Kırklareli	Kirklareli	743165
 TR.37	Kastamonu	Kastamonu	743881
-TR.84	Kars	Kars	743942
+TR.84	Kars Province	Kars Province	743942
 TR.34	Istanbul	Istanbul	745042
-TR.69	Gümüşhane	Gumushane	746423
+TR.69	Gümüşhane Province	Guemueshane Province	746423
 TR.28	Giresun	Giresun	746878
 TR.22	Edirne	Edirne	747711
 TR.19	Çorum	Corum	748877
 TR.82	Çankırı	Cankiri	749747
-TR.17	Çanakkale	Canakkale	749778
-TR.16	Bursa	Bursa	750268
+TR.17	Canakkale	Canakkale	749778
+TR.16	Bursa Province	Bursa Province	750268
 TR.14	Bolu	Bolu	750510
 TR.08	Artvin	Artvin	751816
 TR.05	Amasya	Amasya	752014
 TR.87	Bartın	Bartin	862467
-TR.89	Karabük	Karabuk	862468
+TR.89	Karabük Province	Karabuek Province	862468
 TR.92	Yalova	Yalova	862469
 TR.86	Ardahan	Ardahan	862470
-TR.77	Bayburt	Bayburt	862471
+TR.77	Bayburt Province	Bayburt Province	862471
 TR.93	Düzce	Duzce	865521
 TT.11	Tobago	Tobago	3573606
-TT.10	City of San Fernando	City of San Fernando	3573739
-TT.05	City of Port of Spain	City of Port of Spain	3573891
+TT.10	San Fernando	San Fernando	3573739
+TT.05	Port of Spain	Port of Spain	3573891
 TT.03	Mayaro	Mayaro	3574155
 TT.01	Borough of Arima	Borough of Arima	3575052
 TT.CHA	Chaguanas	Chaguanas	7521937
 TT.CTT	Couva-Tabaquite-Talparo	Couva-Tabaquite-Talparo	7521938
 TT.DMN	Diego Martin	Diego Martin	7521939
-TT.ETO	Eastern Tobago	Eastern Tobago	7521940
 TT.PED	Penal/Debe	Penal/Debe	7521941
 TT.PRT	Princes Town	Princes Town	7521942
 TT.PTF	Point Fortin	Point Fortin	7521943
@@ -3538,7 +3528,7 @@ TV.VAI	Vaitupu	Vaitupu	7601981
 TV.NKF	Nukufetau	Nukufetau	7601982
 TV.NKL	Nukulaelae	Nukulaelae	7601983
 TW.01	Fukien	Fukien	7280288
-TW.02	Kaohsiung	Kaohsiung	7280289
+TW.02	Takao	Takao	7280289
 TW.03	Taipei	Taipei	7280290
 TW.04	Taiwan	Taiwan	7280291
 TZ.19	Kagera	Kagera	148679
@@ -3571,14 +3561,15 @@ TZ.31	Simiyu	Simiyu	8469238
 TZ.28	Geita	Geita	8469239
 TZ.29	Katavi	Katavi	8469240
 TZ.30	Njombe	Njombe	8469241
+TZ.32	Songwe	Songwe	11124984
 UA.27	Zhytomyr	Zhytomyr	686966
-UA.26	Zaporizhia	Zaporizhia	687699
-UA.25	Zakarpattia	Zakarpattia	687869
+UA.26	Zaporizhzhia	Zaporizhzhia	687699
+UA.25	Transcarpathia	Transcarpathia	687869
 UA.24	Volyn	Volyn	689064
-UA.23	Vinnyts'ka	Vinnyts'ka	689559
+UA.23	Vinnytsia	Vinnytsia	689559
 UA.22	Ternopil	Ternopil	691649
 UA.21	Sumy	Sumy	692196
-UA.20	Misto Sevastopol’	Misto Sevastopol'	694422
+UA.20	Sevastopol City	Sevastopol City	694422
 UA.19	Rivne	Rivne	695592
 UA.18	Poltava	Poltava	696634
 UA.17	Odessa	Odessa	698738
@@ -3662,21 +3653,21 @@ US.KY	Kentucky	Kentucky	6254925
 US.MA	Massachusetts	Massachusetts	6254926
 US.PA	Pennsylvania	Pennsylvania	6254927
 US.VA	Virginia	Virginia	6254928
-UY.19	Treinta y Tres	Treinta y Tres	3439780
-UY.18	Tacuarembó	Tacuarembo	3440033
+UY.19	Treinta y Tres Department	Treinta y Tres Department	3439780
+UY.18	Tacuarembó Department	Tacuarembo Department	3440033
 UY.17	Soriano	Soriano	3440054
-UY.16	San José	San Jose	3440645
-UY.15	Salto	Salto	3440711
-UY.14	Rocha	Rocha	3440771
-UY.13	Rivera	Rivera	3440780
-UY.12	Río Negro	Rio Negro	3440789
-UY.11	Paysandú	Paysandu	3441242
-UY.10	Montevideo	Montevideo	3441572
+UY.16	San José Department	San Jose Department	3440645
+UY.15	Salto Department	Salto Department	3440711
+UY.14	Rocha Department	Rocha Department	3440771
+UY.13	Rivera Department	Rivera Department	3440780
+UY.12	Río Negro Department	Rio Negro Department	3440789
+UY.11	Paysandú Department	Paysandu Department	3441242
+UY.10	Montevideo Department	Montevideo Department	3441572
 UY.09	Maldonado	Maldonado	3441890
 UY.08	Lavalleja	Lavalleja	3442007
 UY.07	Florida	Florida	3442584
-UY.06	Flores	Flores	3442587
-UY.05	Durazno	Durazno	3442720
+UY.06	Flores Department	Flores Department	3442587
+UY.05	Durazno Department	Durazno Department	3442720
 UY.04	Colonia	Colonia	3443025
 UY.03	Cerro Largo	Cerro Largo	3443173
 UY.02	Canelones	Canelones	3443411
@@ -3687,8 +3678,8 @@ UZ.10	Samarqand	Samarqand	1114927
 UZ.08	Qashqadaryo	Qashqadaryo	1114928
 UZ.02	Bukhara	Bukhara	1114929
 UZ.14	Toshkent	Toshkent	1484838
-UZ.13	Toshkent Shahri	Toshkent Shahri	1484839
-UZ.16	Sirdaryo	Sirdaryo	1484840
+UZ.13	Tashkent	Tashkent	1484839
+UZ.16	Sirdaryo Region	Sirdaryo Region	1484840
 UZ.07	Navoiy	Navoiy	1484841
 UZ.06	Namangan	Namangan	1484842
 UZ.05	Xorazm	Xorazm	1484843
@@ -3714,7 +3705,7 @@ VE.14	Mérida	Merida	3632306
 VE.13	Lara	Lara	3636539
 VE.12	Guárico	Guarico	3640017
 VE.24	Dependencias Federales	Dependencias Federales	3640846
-VE.25	Capital	Capital	3640847
+VE.25	Distrito Federal	Distrito Federal	3640847
 VE.11	Falcón	Falcon	3640873
 VE.09	Delta Amacuro	Delta Amacuro	3644541
 VE.08	Cojedes	Cojedes	3645386
@@ -3743,11 +3734,11 @@ VN.66	Thừa Thiên-Huế	Thua Thien-Hue	1565033
 VN.55	Kon Tum	Kon Tum	1565088
 VN.34	Thanh Hóa	Thanh Hoa	1566165
 VN.35	Thái Bình	Thai Binh	1566338
-VN.33	Tây Ninh	Tay Ninh	1566557
+VN.33	Tây Ninh Province	Tay Ninh Province	1566557
 VN.32	Sơn La	Son La	1567643
 VN.64	Quảng Trị	Quang Tri	1568733
 VN.30	Quảng Ninh	Quang Ninh	1568758
-VN.63	Quảng Ngãi	Quang Ngai	1568769
+VN.63	Quảng Ngãi Province	Quang Ngai Province	1568769
 VN.62	Quảng Bình	Quang Binh	1568839
 VN.61	Phú Yên	Phu Yen	1569805
 VN.53	Hòa Bình	Hoa Binh	1572594
@@ -3757,27 +3748,27 @@ VN.23	Lâm Đồng	Lam Dong	1577882
 VN.89	Lai Châu	Lai Chau	1577954
 VN.21	Kiến Giang	Kien Giang	1579008
 VN.54	Khánh Hòa	Khanh Hoa	1579634
-VN.20	Ho Chi Minh City	Ho Chi Minh City	1580578
+VN.20	Ho Chi Minh	Ho Chi Minh	1580578
 VN.52	Hà Tĩnh	Ha Tinh	1580700
 VN.50	Hà Giang	Ha Giang	1581030
 VN.49	Gia Lai	Gia Lai	1581088
-VN.44	Ha Nội	Ha Noi	1581129
-VN.87	Cần Thơ	Can Tho	1581188
-VN.13	Hải Phòng	Hai Phong	1581297
+VN.44	Hanoi	Hanoi	1581129
+VN.87	Can Tho	Can Tho	1581188
+VN.13	Haiphong	Haiphong	1581297
 VN.47	Bình Thuận	Binh Thuan	1581882
 VN.09	Đồng Tháp	Dong Thap	1582562
 VN.43	Đồng Nai	Dong Nai	1582720
-VN.88	Ðắc Lắk	Dac Lak	1584169
+VN.88	Đắk Lắk	GJak Lak	1584169
 VN.45	Bà Rịa-Vũng Tàu	Ba Ria-Vung Tau	1584534
 VN.05	Cao Bằng	Cao Bang	1586182
 VN.46	Bình Định	Binh Dinh	1587871
 VN.03	Bến Tre	Ben Tre	1587974
 VN.01	An Giang	An Giang	1594446
 VN.91	Ðắk Nông	Dak Nong	1904987
-VN.92	Huyện Ðiện Biên	Huyen Dien Bien	1905099
+VN.92	Ðiện Biên	Dien Bien	1905099
 VN.74	Bắc Ninh	Bac Ninh	1905412
 VN.71	Bắc Giang	Bac Giang	1905419
-VN.78	Đà Nẵng	Da Nang	1905468
+VN.78	Da Nang	Da Nang	1905468
 VN.75	Bình Dương	Binh Duong	1905475
 VN.76	Bình Phước	Binh Phuoc	1905480
 VN.85	Thái Nguyên	Thai Nguyen	1905497
@@ -3791,16 +3782,16 @@ VN.77	Cà Mau	Ca Mau	1905678
 VN.79	Hải Dương	Hai Duong	1905686
 VN.81	Hưng Yên	Hung Yen	1905699
 VN.86	Vĩnh Phúc	Vinh Phuc	1905856
-VN.93	Hau Giang	Hau Giang	7506719
+VN.93	Hậu Giang	Hau Giang	7506719
 VU.15	Tafea	Tafea	2134739
 VU.13	Sanma	Sanma	2134898
 VU.07	Torba	Torba	2137421
 VU.16	Malampa	Malampa	2208265
 VU.17	Penama	Penama	2208266
 VU.18	Shefa	Shefa	2208267
-WF.98613	Circonscription d'Uvéa	Circonscription d'Uvea	4034759
-WF.98612	Circonscription de Sigavé	Circonscription de Sigave	4034776
-WF.98611	Circonscription d'Alo	Circonscription d'Alo	4034884
+WF.98613	Uvea	Uvea	4034759
+WF.98612	Sigave	Sigave	4034776
+WF.98611	Alo	Alo	4034884
 WS.11	Vaisigano	Vaisigano	4034910
 WS.06	Va‘a-o-Fonoti	Va`a-o-Fonoti	4034943
 WS.10	Tuamasaga	Tuamasaga	4034977
@@ -3821,26 +3812,26 @@ XK.10097360	Pristina	Pristina	10097360
 XK.10097361	Prizren	Prizren	10097361
 YE.25	Ta‘izz	Ta'izz	70222
 YE.05	Shabwah	Shabwah	70935
-YE.16	Sanaa	Sanaa	71132
+YE.16	Sanaa Governorate	Sanaa Governorate	71132
 YE.15	Şa‘dah	Sa'dah	71333
 YE.27	Raymah	Raymah	71532
 YE.14	Ma’rib	Ma'rib	72966
-YE.10	Al Maḩwīt	Al Mahwit	73200
+YE.10	Al Mahwit Governorate	Al Mahwit Governorate	73200
 YE.21	Al Jawf	Al Jawf	74222
-YE.04	Muḩāfaz̧at Ḩaḑramawt	Muhafazat Hadramawt	75411
+YE.04	Muhafazat Hadramaout	Muhafazat Hadramaout	75411
 YE.11	Dhamār	Dhamar	76183
-YE.03	Al Mahrah	Al Mahrah	78985
-YE.08	Muḩāfaz̧at al Ḩudaydah	Muhafazat al Hudaydah	79416
-YE.20	Al Bayḑāʼ	Muhafazat al Bayda'	79838
+YE.03	Al Mahrah Governorate	Al Mahrah Governorate	78985
+YE.08	Al Hudaydah	Al Hudaydah	79416
+YE.20	Al Bayda	Al Bayda	79838
 YE.02	Aden	Aden	80412
-YE.01	Abyan	Abyan	80425
+YE.01	Abyan Governorate	Abyan Governorate	80425
 YE.18	Aḑ Ḑāli‘	Ad Dali'	6201193
 YE.19	Omran	Omran	6201194
 YE.22	Ḩajjah	Hajjah	6201195
-YE.23	Ibb	Ibb	6201196
+YE.23	Ibb Governorate	Ibb Governorate	6201196
 YE.24	Laḩij	Lahij	6201197
-YE.26	Amanat Al Asimah	Amanat Al Asimah	6940571
-YE.28	Soqatra Governorate	Soqatra Governorate	9645387
+YE.26	Amanat Alasimah	Amanat Alasimah	6940571
+YE.28	Soqatra	Soqatra	9645387
 YT.97601	Acoua	Acoua	7521421
 YT.97602	Bandraboua	Bandraboua	7521422
 YT.97603	Bandrele	Bandrele	7521423
@@ -3876,6 +3867,7 @@ ZM.04	Luapula	Luapula	909845
 ZM.03	Eastern	Eastern	917388
 ZM.08	Copperbelt	Copperbelt	917524
 ZM.02	Central	Central	921064
+ZM.10	Muchinga	Muchinga	11154503
 ZW.02	Midlands	Midlands	886119
 ZW.07	Matabeleland South	Matabeleland South	886747
 ZW.06	Matabeleland North	Matabeleland North	886748

--- a/src/data/countryInfo.txt
+++ b/src/data/countryInfo.txt
@@ -1,40 +1,39 @@
-# GeoNames.org Country Information																		
-# ================================																		
-#																		
-#																		
-# CountryCodes:																		
-# ============																		
-#																		
-# The official ISO country code for the United Kingdom is 'GB'. The code 'UK' is reserved.																		
-# 																		
-# A list of dependent countries is available here:																		
-# https://spreadsheets.google.com/ccc?key=pJpyPy-J5JSNhe7F_KxwiCA&hl=en 																		
-#																		
-#																		
-# The countrycode XK temporarily stands for Kosvo:																		
-# http://geonames.wordpress.com/2010/03/08/xk-country-code-for-kosovo/																		
-#																		
-#																		
-# CS (Serbia and Montenegro) with geonameId = 863038 no longer exists.																		
-# AN (the Netherlands Antilles) with geonameId = 3513447  was dissolved on 10 October 2010.																		
-#																		
-#																		
-# Currencies :																		
-# ============																		
-#																		
-# A number of territories are not included in ISO 4217, because their currencies are not per se an independent currency, 																		
-# but a variant of another currency. These currencies are:																		
-#																		
-# 1. FO : Faroese krona (1:1 pegged to the Danish krone)																		
-# 2. GG : Guernsey pound (1:1 pegged to the pound sterling)																		
-# 3. JE : Jersey pound (1:1 pegged to the pound sterling)																		
+# ================================
+#
+#
+# CountryCodes:
+# ============
+#
+# The official ISO country code for the United Kingdom is 'GB'. The code 'UK' is reserved.
+#
+# A list of dependent countries is available here:
+# https://spreadsheets.google.com/ccc?key=pJpyPy-J5JSNhe7F_KxwiCA&hl=en
+#
+#
+# The countrycode XK temporarily stands for Kosvo:
+# http://geonames.wordpress.com/2010/03/08/xk-country-code-for-kosovo/								
+#
+#
+# CS (Serbia and Montenegro) with geonameId = 8505033 no longer exists.
+# AN (the Netherlands Antilles) with geonameId = 8505032 was dissolved on 10 October 2010.
+#
+#
+# Currencies :
+# ============
+#
+# A number of territories are not included in ISO 4217, because their currencies are not per se an independent currency,															
+# but a variant of another currency. These currencies are:
+#
+# 1. FO : Faroese krona (1:1 pegged to the Danish krone)				
+# 2. GG : Guernsey pound (1:1 pegged to the pound sterling)
+# 3. JE : Jersey pound (1:1 pegged to the pound sterling)			
 # 4. IM : Isle of Man pound (1:1 pegged to the pound sterling)																		
-# 5. TV : Tuvaluan dollar (1:1 pegged to the Australian dollar).																		
-# 6. CK : Cook Islands dollar (1:1 pegged to the New Zealand dollar).																		
-#																		
+# 5. TV : Tuvaluan dollar (1:1 pegged to the Australian dollar).											
+# 6. CK : Cook Islands dollar (1:1 pegged to the New Zealand dollar).				
+#	
 # The following non-ISO codes are, however, sometimes used: GGP for the Guernsey pound, 																		
 # JEP for the Jersey pound and IMP for the Isle of Man pound (http://en.wikipedia.org/wiki/ISO_4217)																		
-#																		
+#	
 #																		
 # A list of currency symbols is available here : http://forum.geonames.org/gforum/posts/list/437.page																		
 # another list with fractional units is here: http://forum.geonames.org/gforum/posts/list/1961.page																		
@@ -49,255 +48,255 @@
 # Example : es-AR is the Spanish variant spoken in Argentina.																		
 #																		
 #ISO	ISO3	ISO-Numeric	fips	Country	Capital	Area(in sq km)	Population	Continent	tld	CurrencyCode	CurrencyName	Phone	Postal Code Format	Postal Code Regex	Languages	geonameid	neighbours	EquivalentFipsCode
-AD	AND	020	AN	Andorra	Andorra la Vella	468	84000	EU	.ad	EUR	Euro	376	AD###	^(?:AD)*(\d{3})$	ca	3041565	ES,FR	
-AE	ARE	784	AE	United Arab Emirates	Abu Dhabi	82880	4975593	AS	.ae	AED	Dirham	971			ar-AE,fa,en,hi,ur	290557	SA,OM	
-AF	AFG	004	AF	Afghanistan	Kabul	647500	29121286	AS	.af	AFN	Afghani	93			fa-AF,ps,uz-AF,tk	1149361	TM,CN,IR,TJ,PK,UZ	
-AG	ATG	028	AC	Antigua and Barbuda	St. John's	443	86754	NA	.ag	XCD	Dollar	+1-268			en-AG	3576396		
+AD	AND	020	AN	Andorra	Andorra la Vella	468	77006	EU	.ad	EUR	Euro	376	AD###	^(?:AD)*(\d{3})$	ca	3041565	ES,FR	
+AE	ARE	784	AE	United Arab Emirates	Abu Dhabi	82880	9630959	AS	.ae	AED	Dirham	971			ar-AE,fa,en,hi,ur	290557	SA,OM	
+AF	AFG	004	AF	Afghanistan	Kabul	647500	37172386	AS	.af	AFN	Afghani	93			fa-AF,ps,uz-AF,tk	1149361	TM,CN,IR,TJ,PK,UZ	
+AG	ATG	028	AC	Antigua and Barbuda	St. John's	443	96286	NA	.ag	XCD	Dollar	+1-268			en-AG	3576396		
 AI	AIA	660	AV	Anguilla	The Valley	102	13254	NA	.ai	XCD	Dollar	+1-264			en-AI	3573511		
-AL	ALB	008	AL	Albania	Tirana	28748	2986952	EU	.al	ALL	Lek	355			sq,el	783754	MK,GR,ME,RS,XK	
-AM	ARM	051	AM	Armenia	Yerevan	29800	2968000	AS	.am	AMD	Dram	374	######	^(\d{6})$	hy	174982	GE,IR,AZ,TR	
-AO	AGO	024	AO	Angola	Luanda	1246700	13068161	AF	.ao	AOA	Kwanza	244			pt-AO	3351879	CD,NA,ZM,CG	
+AL	ALB	008	AL	Albania	Tirana	28748	2866376	EU	.al	ALL	Lek	355	####	^(\d{4})$	sq,el	783754	MK,GR,ME,RS,XK	
+AM	ARM	051	AM	Armenia	Yerevan	29800	2951776	AS	.am	AMD	Dram	374	######	^(\d{6})$	hy	174982	GE,IR,AZ,TR	
+AO	AGO	024	AO	Angola	Luanda	1246700	30809762	AF	.ao	AOA	Kwanza	244			pt-AO	3351879	CD,NA,ZM,CG	
 AQ	ATA	010	AY	Antarctica		14000000	0	AN	.aq							6697173		
-AR	ARG	032	AR	Argentina	Buenos Aires	2766890	41343201	SA	.ar	ARS	Peso	54	@####@@@	^([A-Z]\d{4}[A-Z]{3})$	es-AR,en,it,de,fr,gn	3865483	CL,BO,UY,PY,BR	
-AS	ASM	016	AQ	American Samoa	Pago Pago	199	57881	OC	.as	USD	Dollar	+1-684			en-AS,sm,to	5880801		
-AT	AUT	040	AU	Austria	Vienna	83858	8205000	EU	.at	EUR	Euro	43	####	^(\d{4})$	de-AT,hr,hu,sl	2782113	CH,DE,HU,SK,CZ,IT,SI,LI	
-AU	AUS	036	AS	Australia	Canberra	7686850	21515754	OC	.au	AUD	Dollar	61	####	^(\d{4})$	en-AU	2077456		
-AW	ABW	533	AA	Aruba	Oranjestad	193	71566	NA	.aw	AWG	Guilder	297			nl-AW,es,en	3577279		
-AX	ALA	248		Aland Islands	Mariehamn		26711	EU	.ax	EUR	Euro	+358-18	#####	^(?:FI)*(\d{5})$	sv-AX	661882		FI
-AZ	AZE	031	AJ	Azerbaijan	Baku	86600	8303512	AS	.az	AZN	Manat	994	AZ ####	^(?:AZ)*(\d{4})$	az,ru,hy	587116	GE,IR,AM,TR,RU	
-BA	BIH	070	BK	Bosnia and Herzegovina	Sarajevo	51129	4590000	EU	.ba	BAM	Marka	387	#####	^(\d{5})$	bs,hr-BA,sr-BA	3277605	HR,ME,RS	
-BB	BRB	052	BB	Barbados	Bridgetown	431	285653	NA	.bb	BBD	Dollar	+1-246	BB#####	^(?:BB)*(\d{5})$	en-BB	3374084		
-BD	BGD	050	BG	Bangladesh	Dhaka	144000	156118464	AS	.bd	BDT	Taka	880	####	^(\d{4})$	bn-BD,en	1210997	MM,IN	
-BE	BEL	056	BE	Belgium	Brussels	30510	10403000	EU	.be	EUR	Euro	32	####	^(\d{4})$	nl-BE,fr-BE,de-BE	2802361	DE,NL,LU,FR	
-BF	BFA	854	UV	Burkina Faso	Ouagadougou	274200	16241811	AF	.bf	XOF	Franc	226			fr-BF	2361809	NE,BJ,GH,CI,TG,ML	
-BG	BGR	100	BU	Bulgaria	Sofia	110910	7148785	EU	.bg	BGN	Lev	359	####	^(\d{4})$	bg,tr-BG	732800	MK,GR,RO,TR,RS	
-BH	BHR	048	BA	Bahrain	Manama	665	738004	AS	.bh	BHD	Dinar	973	####|###	^(\d{3}\d?)$	ar-BH,en,fa,ur	290291		
-BI	BDI	108	BY	Burundi	Bujumbura	27830	9863117	AF	.bi	BIF	Franc	257			fr-BI,rn	433561	TZ,CD,RW	
-BJ	BEN	204	BN	Benin	Porto-Novo	112620	9056010	AF	.bj	XOF	Franc	229			fr-BJ	2395170	NE,TG,BF,NG	
-BL	BLM	652	TB	Saint Barthelemy	Gustavia	21	8450	NA	.gp	EUR	Euro	590	### ###		fr	3578476		
-BM	BMU	060	BD	Bermuda	Hamilton	53	65365	NA	.bm	BMD	Dollar	+1-441	@@ ##	^([A-Z]{2}\d{2})$	en-BM,pt	3573345		
-BN	BRN	096	BX	Brunei	Bandar Seri Begawan	5770	395027	AS	.bn	BND	Dollar	673	@@####	^([A-Z]{2}\d{4})$	ms-BN,en-BN	1820814	MY	
-BO	BOL	068	BL	Bolivia	Sucre	1098580	9947418	SA	.bo	BOB	Boliviano	591			es-BO,qu,ay	3923057	PE,CL,PY,BR,AR	
-BQ	BES	535		Bonaire, Saint Eustatius and Saba 			18012	NA	.bq	USD	Dollar	599			nl,pap,en	7626844		
-BR	BRA	076	BR	Brazil	Brasilia	8511965	201103330	SA	.br	BRL	Real	55	#####-###	^(\d{8})$	pt-BR,es,en,fr	3469034	SR,PE,BO,UY,GY,PY,GF,VE,CO,AR	
-BS	BHS	044	BF	Bahamas	Nassau	13940	301790	NA	.bs	BSD	Dollar	+1-242			en-BS	3572887		
-BT	BTN	064	BT	Bhutan	Thimphu	47000	699847	AS	.bt	BTN	Ngultrum	975			dz	1252634	CN,IN	
-BV	BVT	074	BV	Bouvet Island			0	AN	.bv	NOK	Krone					3371123		
-BW	BWA	072	BC	Botswana	Gaborone	600370	2029307	AF	.bw	BWP	Pula	267			en-BW,tn-BW	933860	ZW,ZA,NA	
-BY	BLR	112	BO	Belarus	Minsk	207600	9685000	EU	.by	BYR	Ruble	375	######	^(\d{6})$	be,ru	630336	PL,LT,UA,RU,LV	
-BZ	BLZ	084	BH	Belize	Belmopan	22966	314522	NA	.bz	BZD	Dollar	501			en-BZ,es	3582678	GT,MX	
-CA	CAN	124	CA	Canada	Ottawa	9984670	33679000	NA	.ca	CAD	Dollar	1	@#@ #@#	^([ABCEGHJKLMNPRSTVXY]\d[ABCEGHJKLMNPRSTVWXYZ]) ?(\d[ABCEGHJKLMNPRSTVWXYZ]\d)$ 	en-CA,fr-CA,iu	6251999	US	
+AR	ARG	032	AR	Argentina	Buenos Aires	2766890	44494502	SA	.ar	ARS	Peso	54	@####@@@	^[A-Z]?\d{4}[A-Z]{0,3}$	es-AR,en,it,de,fr,gn	3865483	CL,BO,UY,PY,BR	
+AS	ASM	016	AQ	American Samoa	Pago Pago	199	55465	OC	.as	USD	Dollar	+1-684	#####-####	96799	en-AS,sm,to	5880801		
+AT	AUT	040	AU	Austria	Vienna	83858	8847037	EU	.at	EUR	Euro	43	####	^(\d{4})$	de-AT,hr,hu,sl	2782113	CH,DE,HU,SK,CZ,IT,SI,LI	
+AU	AUS	036	AS	Australia	Canberra	7686850	24992369	OC	.au	AUD	Dollar	61	####	^(\d{4})$	en-AU	2077456		
+AW	ABW	533	AA	Aruba	Oranjestad	193	105845	NA	.aw	AWG	Guilder	297			nl-AW,pap,es,en	3577279		
+AX	ALA	248		Aland Islands	Mariehamn	1580	26711	EU	.ax	EUR	Euro	+358-18	#####	^(?:FI)*(\d{5})$	sv-AX	661882		FI
+AZ	AZE	031	AJ	Azerbaijan	Baku	86600	9942334	AS	.az	AZN	Manat	994	AZ ####	^(?:AZ)*(\d{4})$	az,ru,hy	587116	GE,IR,AM,TR,RU	
+BA	BIH	070	BK	Bosnia and Herzegovina	Sarajevo	51129	3323929	EU	.ba	BAM	Marka	387	#####	^(\d{5})$	bs,hr-BA,sr-BA	3277605	HR,ME,RS	
+BB	BRB	052	BB	Barbados	Bridgetown	431	286641	NA	.bb	BBD	Dollar	+1-246	BB#####	^(?:BB)*(\d{5})$	en-BB	3374084		
+BD	BGD	050	BG	Bangladesh	Dhaka	144000	161356039	AS	.bd	BDT	Taka	880	####	^(\d{4})$	bn-BD,en	1210997	MM,IN	
+BE	BEL	056	BE	Belgium	Brussels	30510	11422068	EU	.be	EUR	Euro	32	####	^(\d{4})$	nl-BE,fr-BE,de-BE	2802361	DE,NL,LU,FR	
+BF	BFA	854	UV	Burkina Faso	Ouagadougou	274200	19751535	AF	.bf	XOF	Franc	226			fr-BF,mos	2361809	NE,BJ,GH,CI,TG,ML	
+BG	BGR	100	BU	Bulgaria	Sofia	110910	7000039	EU	.bg	BGN	Lev	359	####	^(\d{4})$	bg,tr-BG,rom	732800	MK,GR,RO,TR,RS	
+BH	BHR	048	BA	Bahrain	Manama	665	1569439	AS	.bh	BHD	Dinar	973	####|###	^(\d{3}\d?)$	ar-BH,en,fa,ur	290291		
+BI	BDI	108	BY	Burundi	Gitega	27830	11175378	AF	.bi	BIF	Franc	257			fr-BI,rn	433561	TZ,CD,RW	
+BJ	BEN	204	BN	Benin	Porto-Novo	112620	11485048	AF	.bj	XOF	Franc	229			fr-BJ	2395170	NE,TG,BF,NG	
+BL	BLM	652	TB	Saint Barthelemy	Gustavia	21	8450	NA	.gp	EUR	Euro	590	#####	^(\d{5})$	fr	3578476		
+BM	BMU	060	BD	Bermuda	Hamilton	53	63968	NA	.bm	BMD	Dollar	+1-441	@@ ##	^([A-Z]{2}\d{2})$	en-BM,pt	3573345		
+BN	BRN	096	BX	Brunei	Bandar Seri Begawan	5770	428962	AS	.bn	BND	Dollar	673	@@####	^([A-Z]{2}\d{4})$	ms-BN,en-BN	1820814	MY	
+BO	BOL	068	BL	Bolivia	Sucre	1098580	11353142	SA	.bo	BOB	Boliviano	591			es-BO,qu,ay	3923057	PE,CL,PY,BR,AR	
+BQ	BES	535		Bonaire, Saint Eustatius and Saba 		328	18012	NA	.bq	USD	Dollar	599			nl,pap,en	7626844		
+BR	BRA	076	BR	Brazil	Brasilia	8511965	209469333	SA	.br	BRL	Real	55	#####-###	^\d{5}-\d{3}$	pt-BR,es,en,fr	3469034	SR,PE,BO,UY,GY,PY,GF,VE,CO,AR	
+BS	BHS	044	BF	Bahamas	Nassau	13940	385640	NA	.bs	BSD	Dollar	+1-242			en-BS	3572887		
+BT	BTN	064	BT	Bhutan	Thimphu	47000	754394	AS	.bt	BTN	Ngultrum	975			dz	1252634	CN,IN	
+BV	BVT	074	BV	Bouvet Island		49	0	AN	.bv	NOK	Krone					3371123		
+BW	BWA	072	BC	Botswana	Gaborone	600370	2254126	AF	.bw	BWP	Pula	267			en-BW,tn-BW	933860	ZW,ZA,NA	
+BY	BLR	112	BO	Belarus	Minsk	207600	9485386	EU	.by	BYN	Belarusian ruble	375	######	^(\d{6})$	be,ru	630336	PL,LT,UA,RU,LV	
+BZ	BLZ	084	BH	Belize	Belmopan	22966	383071	NA	.bz	BZD	Dollar	501			en-BZ,es	3582678	GT,MX	
+CA	CAN	124	CA	Canada	Ottawa	9984670	37058856	NA	.ca	CAD	Dollar	1	@#@ #@#	^([ABCEGHJKLMNPRSTVXY]\d[ABCEGHJKLMNPRSTVWXYZ]) ?(\d[ABCEGHJKLMNPRSTVWXYZ]\d)$ 	en-CA,fr-CA,iu	6251999	US	
 CC	CCK	166	CK	Cocos Islands	West Island	14	628	AS	.cc	AUD	Dollar	61			ms-CC,en	1547376		
-CD	COD	180	CG	Democratic Republic of the Congo	Kinshasa	2345410	70916439	AF	.cd	CDF	Franc	243			fr-CD,ln,kg	203312	TZ,CF,SS,RW,ZM,BI,UG,CG,AO	
-CF	CAF	140	CT	Central African Republic	Bangui	622984	4844927	AF	.cf	XAF	Franc	236			fr-CF,sg,ln,kg	239880	TD,SD,CD,SS,CM,CG	
-CG	COG	178	CF	Republic of the Congo	Brazzaville	342000	3039126	AF	.cg	XAF	Franc	242			fr-CG,kg,ln-CG	2260494	CF,GA,CD,CM,AO	
-CH	CHE	756	SZ	Switzerland	Berne	41290	7581000	EU	.ch	CHF	Franc	41	####	^(\d{4})$	de-CH,fr-CH,it-CH,rm	2658434	DE,IT,LI,FR,AT	
-CI	CIV	384	IV	Ivory Coast	Yamoussoukro	322460	21058798	AF	.ci	XOF	Franc	225			fr-CI	2287781	LR,GH,GN,BF,ML	
+CD	COD	180	CG	Democratic Republic of the Congo	Kinshasa	2345410	84068091	AF	.cd	CDF	Franc	243			fr-CD,ln,ktu,kg,sw,lua	203312	TZ,CF,SS,RW,ZM,BI,UG,CG,AO	
+CF	CAF	140	CT	Central African Republic	Bangui	622984	4666377	AF	.cf	XAF	Franc	236			fr-CF,sg,ln,kg	239880	TD,SD,CD,SS,CM,CG	
+CG	COG	178	CF	Republic of the Congo	Brazzaville	342000	5244363	AF	.cg	XAF	Franc	242			fr-CG,kg,ln-CG	2260494	CF,GA,CD,CM,AO	
+CH	CHE	756	SZ	Switzerland	Bern	41290	8516543	EU	.ch	CHF	Franc	41	####	^(\d{4})$	de-CH,fr-CH,it-CH,rm	2658434	DE,IT,LI,FR,AT	
+CI	CIV	384	IV	Ivory Coast	Yamoussoukro	322460	25069229	AF	.ci	XOF	Franc	225			fr-CI	2287781	LR,GH,GN,BF,ML	
 CK	COK	184	CW	Cook Islands	Avarua	240	21388	OC	.ck	NZD	Dollar	682			en-CK,mi	1899402		
-CL	CHL	152	CI	Chile	Santiago	756950	16746491	SA	.cl	CLP	Peso	56	#######	^(\d{7})$	es-CL	3895114	PE,BO,AR	
-CM	CMR	120	CM	Cameroon	Yaounde	475440	19294149	AF	.cm	XAF	Franc	237			en-CM,fr-CM	2233387	TD,CF,GA,GQ,CG,NG	
-CN	CHN	156	CH	China	Beijing	9596960	1330044000	AS	.cn	CNY	Yuan Renminbi	86	######	^(\d{6})$	zh-CN,yue,wuu,dta,ug,za	1814991	LA,BT,TJ,KZ,MN,AF,NP,MM,KG,PK,KP,RU,VN,IN	
-CO	COL	170	CO	Colombia	Bogota	1138910	47790000	SA	.co	COP	Peso	57			es-CO	3686110	EC,PE,PA,BR,VE	
-CR	CRI	188	CS	Costa Rica	San Jose	51100	4516220	NA	.cr	CRC	Colon	506	####	^(\d{4})$	es-CR,en	3624060	PA,NI	
-CU	CUB	192	CU	Cuba	Havana	110860	11423000	NA	.cu	CUP	Peso	53	CP #####	^(?:CP)*(\d{5})$	es-CU	3562981	US	
-CV	CPV	132	CV	Cape Verde	Praia	4033	508659	AF	.cv	CVE	Escudo	238	####	^(\d{4})$	pt-CV	3374766		
-CW	CUW	531	UC	Curacao	 Willemstad		141766	NA	.cw	ANG	Guilder	599			nl,pap	7626836		
-CX	CXR	162	KT	Christmas Island	Flying Fish Cove	135	1500	AS	.cx	AUD	Dollar	61	####	^(\d{4})$	en,zh,ms-CC	2078138		
-CY	CYP	196	CY	Cyprus	Nicosia	9250	1102677	EU	.cy	EUR	Euro	357	####	^(\d{4})$	el-CY,tr-CY,en	146669		
-CZ	CZE	203	EZ	Czech Republic	Prague	78866	10476000	EU	.cz	CZK	Koruna	420	### ##	^(\d{5})$	cs,sk	3077311	PL,DE,SK,AT	
-DE	DEU	276	GM	Germany	Berlin	357021	81802257	EU	.de	EUR	Euro	49	#####	^(\d{5})$	de	2921044	CH,PL,NL,DK,BE,CZ,LU,FR,AT	
-DJ	DJI	262	DJ	Djibouti	Djibouti	23000	740528	AF	.dj	DJF	Franc	253			fr-DJ,ar,so-DJ,aa	223816	ER,ET,SO	
-DK	DNK	208	DA	Denmark	Copenhagen	43094	5484000	EU	.dk	DKK	Krone	45	####	^(\d{4})$	da-DK,en,fo,de-DK	2623032	DE	
-DM	DMA	212	DO	Dominica	Roseau	754	72813	NA	.dm	XCD	Dollar	+1-767			en-DM	3575830		
-DO	DOM	214	DR	Dominican Republic	Santo Domingo	48730	9823821	NA	.do	DOP	Peso	+1-809 and 1-829	#####	^(\d{5})$	es-DO	3508796	HT	
-DZ	DZA	012	AG	Algeria	Algiers	2381740	34586184	AF	.dz	DZD	Dinar	213	#####	^(\d{5})$	ar-DZ	2589581	NE,EH,LY,MR,TN,MA,ML	
-EC	ECU	218	EC	Ecuador	Quito	283560	14790608	SA	.ec	USD	Dollar	593	@####@	^([a-zA-Z]\d{4}[a-zA-Z])$	es-EC	3658394	PE,CO	
-EE	EST	233	EN	Estonia	Tallinn	45226	1291170	EU	.ee	EUR	Euro	372	#####	^(\d{5})$	et,ru	453733	RU,LV	
-EG	EGY	818	EG	Egypt	Cairo	1001450	80471869	AF	.eg	EGP	Pound	20	#####	^(\d{5})$	ar-EG,en,fr	357994	LY,SD,IL,PS	
+CL	CHL	152	CI	Chile	Santiago	756950	18729160	SA	.cl	CLP	Peso	56	#######	^(\d{7})$	es-CL	3895114	PE,BO,AR	
+CM	CMR	120	CM	Cameroon	Yaounde	475440	25216237	AF	.cm	XAF	Franc	237			en-CM,fr-CM	2233387	TD,CF,GA,GQ,CG,NG	
+CN	CHN	156	CH	China	Beijing	9596960	1411778724	AS	.cn	CNY	Yuan Renminbi	86	######	^(\d{6})$	zh-CN,yue,wuu,dta,ug,za	1814991	LA,BT,TJ,KZ,MN,AF,NP,MM,KG,PK,KP,RU,VN,IN	
+CO	COL	170	CO	Colombia	Bogota	1138910	49648685	SA	.co	COP	Peso	57	######	^(\d{6})$	es-CO	3686110	EC,PE,PA,BR,VE	
+CR	CRI	188	CS	Costa Rica	San Jose	51100	4999441	NA	.cr	CRC	Colon	506	#####	^(\d{5})$	es-CR,en	3624060	PA,NI	
+CU	CUB	192	CU	Cuba	Havana	110860	11338138	NA	.cu	CUP	Peso	53	CP #####	^(?:CP)*(\d{5})$	es-CU,pap	3562981	US	
+CV	CPV	132	CV	Cabo Verde	Praia	4033	543767	AF	.cv	CVE	Escudo	238	####	^(\d{4})$	pt-CV	3374766		
+CW	CUW	531	UC	Curacao	 Willemstad	444	159849	NA	.cw	ANG	Guilder	599			nl,pap	7626836		
+CX	CXR	162	KT	Christmas Island	Flying Fish Cove	135	1500	OC	.cx	AUD	Dollar	61	####	^(\d{4})$	en,zh,ms-CX	2078138		
+CY	CYP	196	CY	Cyprus	Nicosia	9250	1189265	EU	.cy	EUR	Euro	357	####	^(\d{4})$	el-CY,tr-CY,en	146669		
+CZ	CZE	203	EZ	Czechia	Prague	78866	10625695	EU	.cz	CZK	Koruna	420	### ##	^\d{3}\s?\d{2}$	cs,sk	3077311	PL,DE,SK,AT	
+DE	DEU	276	GM	Germany	Berlin	357021	82927922	EU	.de	EUR	Euro	49	#####	^(\d{5})$	de	2921044	CH,PL,NL,DK,BE,CZ,LU,FR,AT	
+DJ	DJI	262	DJ	Djibouti	Djibouti	23000	958920	AF	.dj	DJF	Franc	253			fr-DJ,ar,so-DJ,aa	223816	ER,ET,SO	
+DK	DNK	208	DA	Denmark	Copenhagen	43094	5797446	EU	.dk	DKK	Krone	45	####	^(\d{4})$	da-DK,en,fo,de-DK	2623032	DE	
+DM	DMA	212	DO	Dominica	Roseau	754	71625	NA	.dm	XCD	Dollar	+1-767			en-DM	3575830		
+DO	DOM	214	DR	Dominican Republic	Santo Domingo	48730	10627165	NA	.do	DOP	Peso	+1-809 and 1-829	#####	^(\d{5})$	es-DO	3508796	HT	
+DZ	DZA	012	AG	Algeria	Algiers	2381740	42228429	AF	.dz	DZD	Dinar	213	#####	^(\d{5})$	ar-DZ	2589581	NE,EH,LY,MR,TN,MA,ML	
+EC	ECU	218	EC	Ecuador	Quito	283560	17084357	SA	.ec	USD	Dollar	593	@####@	^([a-zA-Z]\d{4}[a-zA-Z])$	es-EC	3658394	PE,CO	
+EE	EST	233	EN	Estonia	Tallinn	45226	1320884	EU	.ee	EUR	Euro	372	#####	^(\d{5})$	et,ru	453733	RU,LV	
+EG	EGY	818	EG	Egypt	Cairo	1001450	98423595	AF	.eg	EGP	Pound	20	#####	^(\d{5})$	ar-EG,en,fr	357994	LY,SD,IL,PS	
 EH	ESH	732	WI	Western Sahara	El-Aaiun	266000	273008	AF	.eh	MAD	Dirham	212			ar,mey	2461445	DZ,MR,MA	
-ER	ERI	232	ER	Eritrea	Asmara	121320	5792984	AF	.er	ERN	Nakfa	291			aa-ER,ar,tig,kun,ti-ER	338010	ET,SD,DJ	
-ES	ESP	724	SP	Spain	Madrid	504782	46505963	EU	.es	EUR	Euro	34	#####	^(\d{5})$	es-ES,ca,gl,eu,oc	2510769	AD,PT,GI,FR,MA	
-ET	ETH	231	ET	Ethiopia	Addis Ababa	1127127	88013491	AF	.et	ETB	Birr	251	####	^(\d{4})$	am,en-ET,om-ET,ti-ET,so-ET,sid	337996	ER,KE,SD,SS,SO,DJ	
-FI	FIN	246	FI	Finland	Helsinki	337030	5244000	EU	.fi	EUR	Euro	358	#####	^(?:FI)*(\d{5})$	fi-FI,sv-FI,smn	660013	NO,RU,SE	
-FJ	FJI	242	FJ	Fiji	Suva	18270	875983	OC	.fj	FJD	Dollar	679			en-FJ,fj	2205218		
+ER	ERI	232	ER	Eritrea	Asmara	121320	6209262	AF	.er	ERN	Nakfa	291			aa-ER,ar,tig,kun,ti-ER	338010	ET,SD,DJ	
+ES	ESP	724	SP	Spain	Madrid	504782	46723749	EU	.es	EUR	Euro	34	#####	^(\d{5})$	es-ES,ca,gl,eu,oc	2510769	AD,PT,GI,FR,MA	
+ET	ETH	231	ET	Ethiopia	Addis Ababa	1127127	109224559	AF	.et	ETB	Birr	251	####	^(\d{4})$	am,en-ET,om-ET,ti-ET,so-ET,sid	337996	ER,KE,SD,SS,SO,DJ	
+FI	FIN	246	FI	Finland	Helsinki	337030	5518050	EU	.fi	EUR	Euro	358	#####	^(?:FI)*(\d{5})$	fi-FI,sv-FI,smn	660013	NO,RU,SE	
+FJ	FJI	242	FJ	Fiji	Suva	18270	883483	OC	.fj	FJD	Dollar	679			en-FJ,fj	2205218		
 FK	FLK	238	FK	Falkland Islands	Stanley	12173	2638	SA	.fk	FKP	Pound	500			en-FK	3474414		
-FM	FSM	583	FM	Micronesia	Palikir	702	107708	OC	.fm	USD	Dollar	691	#####	^(\d{5})$	en-FM,chk,pon,yap,kos,uli,woe,nkr,kpg	2081918		
-FO	FRO	234	FO	Faroe Islands	Torshavn	1399	48228	EU	.fo	DKK	Krone	298	FO-###	^(?:FO)*(\d{3})$	fo,da-FO	2622320		
-FR	FRA	250	FR	France	Paris	547030	64768389	EU	.fr	EUR	Euro	33	#####	^(\d{5})$	fr-FR,frp,br,co,ca,eu,oc	3017382	CH,DE,BE,LU,IT,AD,MC,ES	
-GA	GAB	266	GB	Gabon	Libreville	267667	1545255	AF	.ga	XAF	Franc	241			fr-GA	2400553	CM,GQ,CG	
-GB	GBR	826	UK	United Kingdom	London	244820	62348447	EU	.uk	GBP	Pound	44	@# #@@|@## #@@|@@# #@@|@@## #@@|@#@ #@@|@@#@ #@@|GIR0AA	^(([A-Z]\d{2}[A-Z]{2})|([A-Z]\d{3}[A-Z]{2})|([A-Z]{2}\d{2}[A-Z]{2})|([A-Z]{2}\d{3}[A-Z]{2})|([A-Z]\d[A-Z]\d[A-Z]{2})|([A-Z]{2}\d[A-Z]\d[A-Z]{2})|(GIR0AA))$	en-GB,cy-GB,gd	2635167	IE	
-GD	GRD	308	GJ	Grenada	St. George's	344	107818	NA	.gd	XCD	Dollar	+1-473			en-GD	3580239		
-GE	GEO	268	GG	Georgia	Tbilisi	69700	4630000	AS	.ge	GEL	Lari	995	####	^(\d{4})$	ka,ru,hy,az	614540	AM,AZ,TR,RU	
+FM	FSM	583	FM	Micronesia	Palikir	702	112640	OC	.fm	USD	Dollar	691	#####	^(\d{5})$	en-FM,chk,pon,yap,kos,uli,woe,nkr,kpg	2081918		
+FO	FRO	234	FO	Faroe Islands	Torshavn	1399	48497	EU	.fo	DKK	Krone	298	###	^(?:FO)*(\d{3})$	fo,da-FO	2622320		
+FR	FRA	250	FR	France	Paris	547030	66987244	EU	.fr	EUR	Euro	33	#####	^(\d{5})$	fr-FR,frp,br,co,ca,eu,oc	3017382	CH,DE,BE,LU,IT,AD,MC,ES	
+GA	GAB	266	GB	Gabon	Libreville	267667	2119275	AF	.ga	XAF	Franc	241			fr-GA	2400553	CM,GQ,CG	
+GB	GBR	826	UK	United Kingdom	London	244820	66488991	EU	.uk	GBP	Pound	44	@# #@@|@## #@@|@@# #@@|@@## #@@|@#@ #@@|@@#@ #@@|GIR0AA	^([Gg][Ii][Rr]\s?0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))\s?[0-9][A-Za-z]{2})$	en-GB,cy-GB,gd	2635167	IE	
+GD	GRD	308	GJ	Grenada	St. George's	344	111454	NA	.gd	XCD	Dollar	+1-473			en-GD	3580239		
+GE	GEO	268	GG	Georgia	Tbilisi	69700	3731000	AS	.ge	GEL	Lari	995	####	^(\d{4})$	ka,ru,hy,az	614540	AM,AZ,TR,RU	
 GF	GUF	254	FG	French Guiana	Cayenne	91000	195506	SA	.gf	EUR	Euro	594	#####	^((97|98)3\d{2})$	fr-GF	3381670	SR,BR	
-GG	GGY	831	GK	Guernsey	St Peter Port	78	65228	EU	.gg	GBP	Pound	+44-1481	@# #@@|@## #@@|@@# #@@|@@## #@@|@#@ #@@|@@#@ #@@|GIR0AA	^(([A-Z]\d{2}[A-Z]{2})|([A-Z]\d{3}[A-Z]{2})|([A-Z]{2}\d{2}[A-Z]{2})|([A-Z]{2}\d{3}[A-Z]{2})|([A-Z]\d[A-Z]\d[A-Z]{2})|([A-Z]{2}\d[A-Z]\d[A-Z]{2})|(GIR0AA))$	en,fr	3042362		
-GH	GHA	288	GH	Ghana	Accra	239460	24339838	AF	.gh	GHS	Cedi	233			en-GH,ak,ee,tw	2300660	CI,TG,BF	
-GI	GIB	292	GI	Gibraltar	Gibraltar	6.5	27884	EU	.gi	GIP	Pound	350			en-GI,es,it,pt	2411586	ES	
-GL	GRL	304	GL	Greenland	Nuuk	2166086	56375	NA	.gl	DKK	Krone	299	####	^(\d{4})$	kl,da-GL,en	3425505		
-GM	GMB	270	GA	Gambia	Banjul	11300	1593256	AF	.gm	GMD	Dalasi	220			en-GM,mnk,wof,wo,ff	2413451	SN	
-GN	GIN	324	GV	Guinea	Conakry	245857	10324025	AF	.gn	GNF	Franc	224			fr-GN	2420477	LR,SN,SL,CI,GW,ML	
+GG	GGY	831	GK	Guernsey	St Peter Port	78	65228	EU	.gg	GBP	Pound	+44-1481	@# #@@|@## #@@|@@# #@@|@@## #@@|@#@ #@@|@@#@ #@@|GIR0AA	^((?:(?:[A-PR-UWYZ][A-HK-Y]\d[ABEHMNPRV-Y0-9]|[A-PR-UWYZ]\d[A-HJKPS-UW0-9])\s\d[ABD-HJLNP-UW-Z]{2})|GIR\s?0AA)$	en,nrf	3042362		
+GH	GHA	288	GH	Ghana	Accra	239460	29767108	AF	.gh	GHS	Cedi	233			en-GH,ak,ee,tw	2300660	CI,TG,BF	
+GI	GIB	292	GI	Gibraltar	Gibraltar	6.5	33718	EU	.gi	GIP	Pound	350			en-GI,es,it,pt	2411586	ES	
+GL	GRL	304	GL	Greenland	Nuuk	2166086	56025	NA	.gl	DKK	Krone	299	####	^(\d{4})$	kl,da-GL,en	3425505		
+GM	GMB	270	GA	Gambia	Banjul	11300	2280102	AF	.gm	GMD	Dalasi	220			en-GM,mnk,wof,wo,ff	2413451	SN	
+GN	GIN	324	GV	Guinea	Conakry	245857	12414318	AF	.gn	GNF	Franc	224			fr-GN	2420477	LR,SN,SL,CI,GW,ML	
 GP	GLP	312	GP	Guadeloupe	Basse-Terre	1780	443000	NA	.gp	EUR	Euro	590	#####	^((97|98)\d{3})$	fr-GP	3579143		
-GQ	GNQ	226	EK	Equatorial Guinea	Malabo	28051	1014999	AF	.gq	XAF	Franc	240			es-GQ,fr	2309096	GA,CM	
-GR	GRC	300	GR	Greece	Athens	131940	11000000	EU	.gr	EUR	Euro	30	### ##	^(\d{5})$	el-GR,en,fr	390903	AL,MK,TR,BG	
+GQ	GNQ	226	EK	Equatorial Guinea	Malabo	28051	1308974	AF	.gq	XAF	Franc	240			es-GQ,fr,pt	2309096	GA,CM	
+GR	GRC	300	GR	Greece	Athens	131940	10727668	EU	.gr	EUR	Euro	30	### ##	^(\d{5})$	el-GR,en,fr	390903	AL,MK,TR,BG	
 GS	SGS	239	SX	South Georgia and the South Sandwich Islands	Grytviken	3903	30	AN	.gs	GBP	Pound				en	3474415		
-GT	GTM	320	GT	Guatemala	Guatemala City	108890	13550440	NA	.gt	GTQ	Quetzal	502	#####	^(\d{5})$	es-GT	3595528	MX,HN,BZ,SV	
-GU	GUM	316	GQ	Guam	Hagatna	549	159358	OC	.gu	USD	Dollar	+1-671	969##	^(969\d{2})$	en-GU,ch-GU	4043988		
-GW	GNB	624	PU	Guinea-Bissau	Bissau	36120	1565126	AF	.gw	XOF	Franc	245	####	^(\d{4})$	pt-GW,pov	2372248	SN,GN	
-GY	GUY	328	GY	Guyana	Georgetown	214970	748486	SA	.gy	GYD	Dollar	592			en-GY	3378535	SR,BR,VE	
-HK	HKG	344	HK	Hong Kong	Hong Kong	1092	6898686	AS	.hk	HKD	Dollar	852			zh-HK,yue,zh,en	1819730		
+GT	GTM	320	GT	Guatemala	Guatemala City	108890	17247807	NA	.gt	GTQ	Quetzal	502	#####	^(\d{5})$	es-GT	3595528	MX,HN,BZ,SV	
+GU	GUM	316	GQ	Guam	Hagatna	549	165768	OC	.gu	USD	Dollar	+1-671	969##	^(969\d{2})$	en-GU,ch-GU	4043988		
+GW	GNB	624	PU	Guinea-Bissau	Bissau	36120	1874309	AF	.gw	XOF	Franc	245	####	^(\d{4})$	pt-GW,pov	2372248	SN,GN	
+GY	GUY	328	GY	Guyana	Georgetown	214970	779004	SA	.gy	GYD	Dollar	592			en-GY	3378535	SR,BR,VE	
+HK	HKG	344	HK	Hong Kong	Hong Kong	1092	7451000	AS	.hk	HKD	Dollar	852			zh-HK,yue,zh,en	1819730		
 HM	HMD	334	HM	Heard Island and McDonald Islands		412	0	AN	.hm	AUD	Dollar	 				1547314		
-HN	HND	340	HO	Honduras	Tegucigalpa	112090	7989415	NA	.hn	HNL	Lempira	504	@@####	^([A-Z]{2}\d{4})$	es-HN	3608932	GT,NI,SV	
-HR	HRV	191	HR	Croatia	Zagreb	56542	4491000	EU	.hr	HRK	Kuna	385	#####	^(?:HR)*(\d{5})$	hr-HR,sr	3202326	HU,SI,BA,ME,RS	
-HT	HTI	332	HA	Haiti	Port-au-Prince	27750	9648924	NA	.ht	HTG	Gourde	509	HT####	^(?:HT)*(\d{4})$	ht,fr-HT	3723988	DO	
-HU	HUN	348	HU	Hungary	Budapest	93030	9982000	EU	.hu	HUF	Forint	36	####	^(\d{4})$	hu-HU	719819	SK,SI,RO,UA,HR,AT,RS	
-ID	IDN	360	ID	Indonesia	Jakarta	1919440	242968342	AS	.id	IDR	Rupiah	62	#####	^(\d{5})$	id,en,nl,jv	1643084	PG,TL,MY	
-IE	IRL	372	EI	Ireland	Dublin	70280	4622917	EU	.ie	EUR	Euro	353			en-IE,ga-IE	2963597	GB	
-IL	ISR	376	IS	Israel	Jerusalem	20770	7353985	AS	.il	ILS	Shekel	972	#####	^(\d{5})$	he,ar-IL,en-IL,	294640	SY,JO,LB,EG,PS	
-IM	IMN	833	IM	Isle of Man	Douglas, Isle of Man	572	75049	EU	.im	GBP	Pound	+44-1624	@# #@@|@## #@@|@@# #@@|@@## #@@|@#@ #@@|@@#@ #@@|GIR0AA	^(([A-Z]\d{2}[A-Z]{2})|([A-Z]\d{3}[A-Z]{2})|([A-Z]{2}\d{2}[A-Z]{2})|([A-Z]{2}\d{3}[A-Z]{2})|([A-Z]\d[A-Z]\d[A-Z]{2})|([A-Z]{2}\d[A-Z]\d[A-Z]{2})|(GIR0AA))$	en,gv	3042225		
-IN	IND	356	IN	India	New Delhi	3287590	1173108018	AS	.in	INR	Rupee	91	######	^(\d{6})$	en-IN,hi,bn,te,mr,ta,ur,gu,kn,ml,or,pa,as,bh,sat,ks,ne,sd,kok,doi,mni,sit,sa,fr,lus,inc	1269750	CN,NP,MM,BT,PK,BD	
+HN	HND	340	HO	Honduras	Tegucigalpa	112090	9587522	NA	.hn	HNL	Lempira	504	@@####	^([A-Z]{2}\d{4})$	es-HN,cab,miq	3608932	GT,NI,SV	
+HR	HRV	191	HR	Croatia	Zagreb	56542	3871833	EU	.hr	EUR	Euro	385	#####	^(?:HR)*(\d{5})$	hr-HR,sr	3202326	HU,SI,BA,ME,RS	
+HT	HTI	332	HA	Haiti	Port-au-Prince	27750	11123176	NA	.ht	HTG	Gourde	509	HT####	^(?:HT)*(\d{4})$	ht,fr-HT	3723988	DO	
+HU	HUN	348	HU	Hungary	Budapest	93030	9768785	EU	.hu	HUF	Forint	36	####	^(\d{4})$	hu-HU	719819	SK,SI,RO,UA,HR,AT,RS	
+ID	IDN	360	ID	Indonesia	Jakarta	1919440	267663435	AS	.id	IDR	Rupiah	62	#####	^(\d{5})$	id,en,nl,jv	1643084	PG,TL,MY	
+IE	IRL	372	EI	Ireland	Dublin	70280	4853506	EU	.ie	EUR	Euro	353	@@@ @@@@	^(D6W|[AC-FHKNPRTV-Y][0-9]{2})\s?([AC-FHKNPRTV-Y0-9]{4})	en-IE,ga-IE	2963597	GB	
+IL	ISR	376	IS	Israel	Jerusalem	20770	8883800	AS	.il	ILS	Shekel	972	#######	^(\d{7}|\d{5})$	he,ar-IL,en-IL,	294640	SY,JO,LB,EG,PS	
+IM	IMN	833	IM	Isle of Man	Douglas	572	84077	EU	.im	GBP	Pound	+44-1624	@# #@@|@## #@@|@@# #@@|@@## #@@|@#@ #@@|@@#@ #@@|GIR0AA	^((?:(?:[A-PR-UWYZ][A-HK-Y]\d[ABEHMNPRV-Y0-9]|[A-PR-UWYZ]\d[A-HJKPS-UW0-9])\s\d[ABD-HJLNP-UW-Z]{2})|GIR\s?0AA)$	en,gv	3042225		
+IN	IND	356	IN	India	New Delhi	3287590	1352617328	AS	.in	INR	Rupee	91	######	^(\d{6})$	en-IN,hi,bn,te,mr,ta,ur,gu,kn,ml,or,pa,as,bh,sat,ks,ne,sd,kok,doi,mni,sit,sa,fr,lus,inc	1269750	CN,NP,MM,BT,PK,BD	
 IO	IOT	086	IO	British Indian Ocean Territory	Diego Garcia	60	4000	AS	.io	USD	Dollar	246			en-IO	1282588		
-IQ	IRQ	368	IZ	Iraq	Baghdad	437072	29671605	AS	.iq	IQD	Dinar	964	#####	^(\d{5})$	ar-IQ,ku,hy	99237	SY,SA,IR,JO,TR,KW	
-IR	IRN	364	IR	Iran	Tehran	1648000	76923300	AS	.ir	IRR	Rial	98	##########	^(\d{10})$	fa-IR,ku	130758	TM,AF,IQ,AM,PK,AZ,TR	
-IS	ISL	352	IC	Iceland	Reykjavik	103000	308910	EU	.is	ISK	Krona	354	###	^(\d{3})$	is,en,de,da,sv,no	2629691		
-IT	ITA	380	IT	Italy	Rome	301230	60340328	EU	.it	EUR	Euro	39	#####	^(\d{5})$	it-IT,de-IT,fr-IT,sc,ca,co,sl	3175395	CH,VA,SI,SM,FR,AT	
-JE	JEY	832	JE	Jersey	Saint Helier	116	90812	EU	.je	GBP	Pound	+44-1534	@# #@@|@## #@@|@@# #@@|@@## #@@|@#@ #@@|@@#@ #@@|GIR0AA	^(([A-Z]\d{2}[A-Z]{2})|([A-Z]\d{3}[A-Z]{2})|([A-Z]{2}\d{2}[A-Z]{2})|([A-Z]{2}\d{3}[A-Z]{2})|([A-Z]\d[A-Z]\d[A-Z]{2})|([A-Z]{2}\d[A-Z]\d[A-Z]{2})|(GIR0AA))$	en,pt	3042142		
-JM	JAM	388	JM	Jamaica	Kingston	10991	2847232	NA	.jm	JMD	Dollar	+1-876			en-JM	3489940		
-JO	JOR	400	JO	Jordan	Amman	92300	6407085	AS	.jo	JOD	Dinar	962	#####	^(\d{5})$	ar-JO,en	248816	SY,SA,IQ,IL,PS	
-JP	JPN	392	JA	Japan	Tokyo	377835	127288000	AS	.jp	JPY	Yen	81	###-####	^(\d{7})$	ja	1861060		
-KE	KEN	404	KE	Kenya	Nairobi	582650	40046566	AF	.ke	KES	Shilling	254	#####	^(\d{5})$	en-KE,sw-KE	192950	ET,TZ,SS,SO,UG	
-KG	KGZ	417	KG	Kyrgyzstan	Bishkek	198500	5508626	AS	.kg	KGS	Som	996	######	^(\d{6})$	ky,uz,ru	1527747	CN,TJ,UZ,KZ	
-KH	KHM	116	CB	Cambodia	Phnom Penh	181040	14453680	AS	.kh	KHR	Riels	855	#####	^(\d{5})$	km,fr,en	1831722	LA,TH,VN	
-KI	KIR	296	KR	Kiribati	Tarawa	811	92533	OC	.ki	AUD	Dollar	686			en-KI,gil	4030945		
-KM	COM	174	CN	Comoros	Moroni	2170	773407	AF	.km	KMF	Franc	269			ar,fr-KM	921929		
-KN	KNA	659	SC	Saint Kitts and Nevis	Basseterre	261	51134	NA	.kn	XCD	Dollar	+1-869			en-KN	3575174		
-KP	PRK	408	KN	North Korea	Pyongyang	120540	22912177	AS	.kp	KPW	Won	850	###-###	^(\d{6})$	ko-KP	1873107	CN,KR,RU	
-KR	KOR	410	KS	South Korea	Seoul	98480	48422644	AS	.kr	KRW	Won	82	SEOUL ###-###	^(?:SEOUL)*(\d{6})$	ko-KR,en	1835841	KP	
-XK	XKX	0	KV	Kosovo	Pristina		1800000	EU		EUR	Euro				sq,sr	831053	RS,AL,MK,ME	
-KW	KWT	414	KU	Kuwait	Kuwait City	17820	2789132	AS	.kw	KWD	Dinar	965	#####	^(\d{5})$	ar-KW,en	285570	SA,IQ	
-KY	CYM	136	CJ	Cayman Islands	George Town	262	44270	NA	.ky	KYD	Dollar	+1-345			en-KY	3580718		
-KZ	KAZ	398	KZ	Kazakhstan	Astana	2717300	15340000	AS	.kz	KZT	Tenge	7	######	^(\d{6})$	kk,ru	1522867	TM,CN,KG,UZ,RU	
-LA	LAO	418	LA	Laos	Vientiane	236800	6368162	AS	.la	LAK	Kip	856	#####	^(\d{5})$	lo,fr,en	1655842	CN,MM,KH,TH,VN	
-LB	LBN	422	LE	Lebanon	Beirut	10400	4125247	AS	.lb	LBP	Pound	961	#### ####|####	^(\d{4}(\d{4})?)$	ar-LB,fr-LB,en,hy	272103	SY,IL	
-LC	LCA	662	ST	Saint Lucia	Castries	616	160922	NA	.lc	XCD	Dollar	+1-758			en-LC	3576468		
-LI	LIE	438	LS	Liechtenstein	Vaduz	160	35000	EU	.li	CHF	Franc	423	####	^(\d{4})$	de-LI	3042058	CH,AT	
-LK	LKA	144	CE	Sri Lanka	Colombo	65610	21513990	AS	.lk	LKR	Rupee	94	#####	^(\d{5})$	si,ta,en	1227603		
-LR	LBR	430	LI	Liberia	Monrovia	111370	3685076	AF	.lr	LRD	Dollar	231	####	^(\d{4})$	en-LR	2275384	SL,CI,GN	
-LS	LSO	426	LT	Lesotho	Maseru	30355	1919552	AF	.ls	LSL	Loti	266	###	^(\d{3})$	en-LS,st,zu,xh	932692	ZA	
-LT	LTU	440	LH	Lithuania	Vilnius	65200	2944459	EU	.lt	LTL	Litas	370	LT-#####	^(?:LT)*(\d{5})$	lt,ru,pl	597427	PL,BY,RU,LV	
-LU	LUX	442	LU	Luxembourg	Luxembourg	2586	497538	EU	.lu	EUR	Euro	352	L-####	^(\d{4})$	lb,de-LU,fr-LU	2960313	DE,BE,FR	
-LV	LVA	428	LG	Latvia	Riga	64589	2217969	EU	.lv	EUR	Euro	371	LV-####	^(?:LV)*(\d{4})$	lv,ru,lt	458258	LT,EE,BY,RU	
-LY	LBY	434	LY	Libya	Tripolis	1759540	6461454	AF	.ly	LYD	Dinar	218			ar-LY,it,en	2215636	TD,NE,DZ,SD,TN,EG	
-MA	MAR	504	MO	Morocco	Rabat	446550	31627428	AF	.ma	MAD	Dirham	212	#####	^(\d{5})$	ar-MA,fr	2542007	DZ,EH,ES	
-MC	MCO	492	MN	Monaco	Monaco	1.95	32965	EU	.mc	EUR	Euro	377	#####	^(\d{5})$	fr-MC,en,it	2993457	FR	
-MD	MDA	498	MD	Moldova	Chisinau	33843	4324000	EU	.md	MDL	Leu	373	MD-####	^(?:MD)*(\d{4})$	ro,ru,gag,tr	617790	RO,UA	
-ME	MNE	499	MJ	Montenegro	Podgorica	14026	666730	EU	.me	EUR	Euro	382	#####	^(\d{5})$	sr,hu,bs,sq,hr,rom	3194884	AL,HR,BA,RS,XK	
-MF	MAF	663	RN	Saint Martin	Marigot	53	35925	NA	.gp	EUR	Euro	590	### ###		fr	3578421	SX	
-MG	MDG	450	MA	Madagascar	Antananarivo	587040	21281844	AF	.mg	MGA	Ariary	261	###	^(\d{3})$	fr-MG,mg	1062947		
-MH	MHL	584	RM	Marshall Islands	Majuro	181.3	65859	OC	.mh	USD	Dollar	692			mh,en-MH	2080185		
-MK	MKD	807	MK	Macedonia	Skopje	25333	2062294	EU	.mk	MKD	Denar	389	####	^(\d{4})$	mk,sq,tr,rmm,sr	718075	AL,GR,BG,RS,XK	
-ML	MLI	466	ML	Mali	Bamako	1240000	13796354	AF	.ml	XOF	Franc	223			fr-ML,bm	2453866	SN,NE,DZ,CI,GN,MR,BF	
-MM	MMR	104	BM	Myanmar	Nay Pyi Taw	678500	53414374	AS	.mm	MMK	Kyat	95	#####	^(\d{5})$	my	1327865	CN,LA,TH,BD,IN	
-MN	MNG	496	MG	Mongolia	Ulan Bator	1565000	3086918	AS	.mn	MNT	Tugrik	976	######	^(\d{6})$	mn,ru	2029969	CN,RU	
-MO	MAC	446	MC	Macao	Macao	254	449198	AS	.mo	MOP	Pataca	853			zh,zh-MO,pt	1821275		
-MP	MNP	580	CQ	Northern Mariana Islands	Saipan	477	53883	OC	.mp	USD	Dollar	+1-670			fil,tl,zh,ch-MP,en-MP	4041468		
+IQ	IRQ	368	IZ	Iraq	Baghdad	437072	38433600	AS	.iq	IQD	Dinar	964	#####	^(\d{5})$	ar-IQ,ku,hy	99237	SY,SA,IR,JO,TR,KW	
+IR	IRN	364	IR	Iran	Tehran	1648000	81800269	AS	.ir	IRR	Rial	98	##########	^(\d{10})$	fa-IR,ku	130758	TM,AF,IQ,AM,PK,AZ,TR	
+IS	ISL	352	IC	Iceland	Reykjavik	103000	353574	EU	.is	ISK	Krona	354	###	^(\d{3})$	is,en,de,da,sv,no	2629691		
+IT	ITA	380	IT	Italy	Rome	301230	60431283	EU	.it	EUR	Euro	39	#####	^(\d{5})$	it-IT,de-IT,fr-IT,sc,ca,co,sl	3175395	CH,VA,SI,SM,FR,AT	
+JE	JEY	832	JE	Jersey	Saint Helier	116	90812	EU	.je	GBP	Pound	+44-1534	@# #@@|@## #@@|@@# #@@|@@## #@@|@#@ #@@|@@#@ #@@|GIR0AA	^((?:(?:[A-PR-UWYZ][A-HK-Y]\d[ABEHMNPRV-Y0-9]|[A-PR-UWYZ]\d[A-HJKPS-UW0-9])\s\d[ABD-HJLNP-UW-Z]{2})|GIR\s?0AA)$	en,fr,nrf	3042142		
+JM	JAM	388	JM	Jamaica	Kingston	10991	2934855	NA	.jm	JMD	Dollar	+1-876			en-JM	3489940		
+JO	JOR	400	JO	Jordan	Amman	92300	9956011	AS	.jo	JOD	Dinar	962	#####	^(\d{5})$	ar-JO,en	248816	SY,SA,IQ,IL,PS	
+JP	JPN	392	JA	Japan	Tokyo	377835	126529100	AS	.jp	JPY	Yen	81	###-####	^\d{3}-\d{4}$	ja	1861060		
+KE	KEN	404	KE	Kenya	Nairobi	582650	51393010	AF	.ke	KES	Shilling	254	#####	^(\d{5})$	en-KE,sw-KE	192950	ET,TZ,SS,SO,UG	
+KG	KGZ	417	KG	Kyrgyzstan	Bishkek	198500	6315800	AS	.kg	KGS	Som	996	######	^(\d{6})$	ky,uz,ru	1527747	CN,TJ,UZ,KZ	
+KH	KHM	116	CB	Cambodia	Phnom Penh	181040	16249798	AS	.kh	KHR	Riels	855	#####	^(\d{5})$	km,fr,en	1831722	LA,TH,VN	
+KI	KIR	296	KR	Kiribati	Tarawa	811	115847	OC	.ki	AUD	Dollar	686			en-KI,gil	4030945		
+KM	COM	174	CN	Comoros	Moroni	2170	832322	AF	.km	KMF	Franc	269			ar,fr-KM	921929		
+KN	KNA	659	SC	Saint Kitts and Nevis	Basseterre	261	52441	NA	.kn	XCD	Dollar	+1-869			en-KN	3575174		
+KP	PRK	408	KN	North Korea	Pyongyang	120540	25549819	AS	.kp	KPW	Won	850	###-###	^(\d{6})$	ko-KP	1873107	CN,KR,RU	
+KR	KOR	410	KS	South Korea	Seoul	98480	51635256	AS	.kr	KRW	Won	82	#####	^(\d{5})$	ko-KR,en	1835841	KP	
+XK	XKX	0	KV	Kosovo	Pristina	10908	1845300	EU		EUR	Euro				sq,sr	831053	RS,AL,MK,ME	
+KW	KWT	414	KU	Kuwait	Kuwait City	17820	4137309	AS	.kw	KWD	Dinar	965	#####	^(\d{5})$	ar-KW,en	285570	SA,IQ	
+KY	CYM	136	CJ	Cayman Islands	George Town	262	64174	NA	.ky	KYD	Dollar	+1-345			en-KY	3580718		
+KZ	KAZ	398	KZ	Kazakhstan	Nur-Sultan	2717300	18276499	AS	.kz	KZT	Tenge	7	######	^(\d{6})$	kk,ru	1522867	TM,CN,KG,UZ,RU	
+LA	LAO	418	LA	Laos	Vientiane	236800	7061507	AS	.la	LAK	Kip	856	#####	^(\d{5})$	lo,fr,en	1655842	CN,MM,KH,TH,VN	
+LB	LBN	422	LE	Lebanon	Beirut	10400	6848925	AS	.lb	LBP	Pound	961	#### ####|####	^(\d{4}(\d{4})?)$	ar-LB,fr-LB,en,hy	272103	SY,IL	
+LC	LCA	662	ST	Saint Lucia	Castries	616	181889	NA	.lc	XCD	Dollar	+1-758			en-LC	3576468		
+LI	LIE	438	LS	Liechtenstein	Vaduz	160	37910	EU	.li	CHF	Franc	423	####	^(\d{4})$	de-LI	3042058	CH,AT	
+LK	LKA	144	CE	Sri Lanka	Colombo	65610	21670000	AS	.lk	LKR	Rupee	94	#####	^(\d{5})$	si,ta,en	1227603		
+LR	LBR	430	LI	Liberia	Monrovia	111370	4818977	AF	.lr	LRD	Dollar	231	####	^(\d{4})$	en-LR	2275384	SL,CI,GN	
+LS	LSO	426	LT	Lesotho	Maseru	30355	2108132	AF	.ls	LSL	Loti	266	###	^(\d{3})$	en-LS,st,zu,xh	932692	ZA	
+LT	LTU	440	LH	Lithuania	Vilnius	65200	2789533	EU	.lt	EUR	Euro	370	LT-#####	^(?:LT)*(\d{5})$	lt,ru,pl	597427	PL,BY,RU,LV	
+LU	LUX	442	LU	Luxembourg	Luxembourg	2586	607728	EU	.lu	EUR	Euro	352	L-####	^(?:L-)?\d{4}$	lb,de-LU,fr-LU	2960313	DE,BE,FR	
+LV	LVA	428	LG	Latvia	Riga	64589	1926542	EU	.lv	EUR	Euro	371	LV-####	^(?:LV)*(\d{4})$	lv,ru,lt	458258	LT,EE,BY,RU	
+LY	LBY	434	LY	Libya	Tripoli	1759540	6678567	AF	.ly	LYD	Dinar	218			ar-LY,it,en	2215636	TD,NE,DZ,SD,TN,EG	
+MA	MAR	504	MO	Morocco	Rabat	446550	36029138	AF	.ma	MAD	Dirham	212	#####	^(\d{5})$	ar-MA,ber,fr	2542007	DZ,EH,ES	
+MC	MCO	492	MN	Monaco	Monaco	1.95	38682	EU	.mc	EUR	Euro	377	#####	^(\d{5})$	fr-MC,en,it	2993457	FR	
+MD	MDA	498	MD	Moldova	Chisinau	33843	3545883	EU	.md	MDL	Leu	373	MD-####	^MD-\d{4}$	ro,ru,gag,tr	617790	RO,UA	
+ME	MNE	499	MJ	Montenegro	Podgorica	14026	622345	EU	.me	EUR	Euro	382	#####	^(\d{5})$	sr,hu,bs,sq,hr,rom	3194884	AL,HR,BA,RS,XK	
+MF	MAF	663	RN	Saint Martin	Marigot	53	37264	NA	.gp	EUR	Euro	590	#####	^(\d{5})$	fr	3578421	SX	
+MG	MDG	450	MA	Madagascar	Antananarivo	587040	26262368	AF	.mg	MGA	Ariary	261	###	^(\d{3})$	fr-MG,mg	1062947		
+MH	MHL	584	RM	Marshall Islands	Majuro	181.3	58413	OC	.mh	USD	Dollar	692	#####-####	^969\d{2}(-\d{4})$	mh,en-MH	2080185		
+MK	MKD	807	MK	North Macedonia	Skopje	25333	2082958	EU	.mk	MKD	Denar	389	####	^(\d{4})$	mk,sq,tr,rmm,sr	718075	AL,GR,BG,RS,XK	
+ML	MLI	466	ML	Mali	Bamako	1240000	19077690	AF	.ml	XOF	Franc	223			fr-ML,bm	2453866	SN,NE,DZ,CI,GN,MR,BF	
+MM	MMR	104	BM	Myanmar	Nay Pyi Taw	678500	53708395	AS	.mm	MMK	Kyat	95	#####	^(\d{5})$	my	1327865	CN,LA,TH,BD,IN	
+MN	MNG	496	MG	Mongolia	Ulaanbaatar	1565000	3170208	AS	.mn	MNT	Tugrik	976	######	^(\d{6})$	mn,ru	2029969	CN,RU	
+MO	MAC	446	MC	Macao	Macao	254	631636	AS	.mo	MOP	Pataca	853			zh,zh-MO,pt	1821275		
+MP	MNP	580	CQ	Northern Mariana Islands	Saipan	477	56882	OC	.mp	USD	Dollar	+1-670	#####	^9695\d{1}$	fil,tl,zh,ch-MP,en-MP	4041468		
 MQ	MTQ	474	MB	Martinique	Fort-de-France	1100	432900	NA	.mq	EUR	Euro	596	#####	^(\d{5})$	fr-MQ	3570311		
-MR	MRT	478	MR	Mauritania	Nouakchott	1030700	3205060	AF	.mr	MRO	Ouguiya	222			ar-MR,fuc,snk,fr,mey,wo	2378080	SN,DZ,EH,ML	
+MR	MRT	478	MR	Mauritania	Nouakchott	1030700	4403319	AF	.mr	MRU	Ouguiya	222			ar-MR,fuc,snk,fr,mey,wo	2378080	SN,DZ,EH,ML	
 MS	MSR	500	MH	Montserrat	Plymouth	102	9341	NA	.ms	XCD	Dollar	+1-664			en-MS	3578097		
-MT	MLT	470	MT	Malta	Valletta	316	403000	EU	.mt	EUR	Euro	356	@@@ ###|@@@ ##	^([A-Z]{3}\d{2}\d?)$	mt,en-MT	2562770		
-MU	MUS	480	MP	Mauritius	Port Louis	2040	1294104	AF	.mu	MUR	Rupee	230			en-MU,bho,fr	934292		
-MV	MDV	462	MV	Maldives	Male	300	395650	AS	.mv	MVR	Rufiyaa	960	#####	^(\d{5})$	dv,en	1282028		
-MW	MWI	454	MI	Malawi	Lilongwe	118480	15447500	AF	.mw	MWK	Kwacha	265			ny,yao,tum,swk	927384	TZ,MZ,ZM	
-MX	MEX	484	MX	Mexico	Mexico City	1972550	112468855	NA	.mx	MXN	Peso	52	#####	^(\d{5})$	es-MX	3996063	GT,US,BZ	
-MY	MYS	458	MY	Malaysia	Kuala Lumpur	329750	28274729	AS	.my	MYR	Ringgit	60	#####	^(\d{5})$	ms-MY,en,zh,ta,te,ml,pa,th	1733045	BN,TH,ID	
-MZ	MOZ	508	MZ	Mozambique	Maputo	801590	22061451	AF	.mz	MZN	Metical	258	####	^(\d{4})$	pt-MZ,vmw	1036973	ZW,TZ,SZ,ZA,ZM,MW	
-NA	NAM	516	WA	Namibia	Windhoek	825418	2128471	AF	.na	NAD	Dollar	264			en-NA,af,de,hz,naq	3355338	ZA,BW,ZM,AO	
-NC	NCL	540	NC	New Caledonia	Noumea	19060	216494	OC	.nc	XPF	Franc	687	#####	^(\d{5})$	fr-NC	2139685		
-NE	NER	562	NG	Niger	Niamey	1267000	15878271	AF	.ne	XOF	Franc	227	####	^(\d{4})$	fr-NE,ha,kr,dje	2440476	TD,BJ,DZ,LY,BF,NG,ML	
+MT	MLT	470	MT	Malta	Valletta	316	483530	EU	.mt	EUR	Euro	356	@@@ ####	^[A-Z]{3}\s?\d{4}$	mt,en-MT	2562770		
+MU	MUS	480	MP	Mauritius	Port Louis	2040	1265303	AF	.mu	MUR	Rupee	230			en-MU,bho,fr	934292		
+MV	MDV	462	MV	Maldives	Male	300	515696	AS	.mv	MVR	Rufiyaa	960	#####	^(\d{5})$	dv,en	1282028		
+MW	MWI	454	MI	Malawi	Lilongwe	118480	17563749	AF	.mw	MWK	Kwacha	265	######	^(\d{6})$	ny,yao,tum,swk	927384	TZ,MZ,ZM	
+MX	MEX	484	MX	Mexico	Mexico City	1972550	126190788	NA	.mx	MXN	Peso	52	#####	^(\d{5})$	es-MX	3996063	GT,US,BZ	
+MY	MYS	458	MY	Malaysia	Kuala Lumpur	329750	31528585	AS	.my	MYR	Ringgit	60	#####	^(\d{5})$	ms-MY,en,zh,ta,te,ml,pa,th	1733045	BN,TH,ID	
+MZ	MOZ	508	MZ	Mozambique	Maputo	801590	29495962	AF	.mz	MZN	Metical	258	####	^(\d{4})$	pt-MZ,vmw	1036973	ZW,TZ,SZ,ZA,ZM,MW	
+NA	NAM	516	WA	Namibia	Windhoek	825418	2448255	AF	.na	NAD	Dollar	264			en-NA,af,de,hz,naq	3355338	ZA,BW,ZM,AO	
+NC	NCL	540	NC	New Caledonia	Noumea	19060	284060	OC	.nc	XPF	Franc	687	#####	^(\d{5})$	fr-NC	2139685		
+NE	NER	562	NG	Niger	Niamey	1267000	22442948	AF	.ne	XOF	Franc	227	####	^(\d{4})$	fr-NE,ha,kr,dje	2440476	TD,BJ,DZ,LY,BF,NG,ML	
 NF	NFK	574	NF	Norfolk Island	Kingston	34.6	1828	OC	.nf	AUD	Dollar	672	####	^(\d{4})$	en-NF	2155115		
-NG	NGA	566	NI	Nigeria	Abuja	923768	154000000	AF	.ng	NGN	Naira	234	######	^(\d{6})$	en-NG,ha,yo,ig,ff	2328926	TD,NE,BJ,CM	
-NI	NIC	558	NU	Nicaragua	Managua	129494	5995928	NA	.ni	NIO	Cordoba	505	###-###-#	^(\d{7})$	es-NI,en	3617476	CR,HN	
-NL	NLD	528	NL	Netherlands	Amsterdam	41526	16645000	EU	.nl	EUR	Euro	31	#### @@	^(\d{4}[A-Z]{2})$	nl-NL,fy-NL	2750405	DE,BE	
-NO	NOR	578	NO	Norway	Oslo	324220	5009150	EU	.no	NOK	Krone	47	####	^(\d{4})$	no,nb,nn,se,fi	3144096	FI,RU,SE	
-NP	NPL	524	NP	Nepal	Kathmandu	140800	28951852	AS	.np	NPR	Rupee	977	#####	^(\d{5})$	ne,en	1282988	CN,IN	
-NR	NRU	520	NR	Nauru	Yaren	21	10065	OC	.nr	AUD	Dollar	674			na,en-NR	2110425		
+NG	NGA	566	NI	Nigeria	Abuja	923768	195874740	AF	.ng	NGN	Naira	234	######	^(\d{6})$	en-NG,ha,yo,ig,ff	2328926	TD,NE,BJ,CM	
+NI	NIC	558	NU	Nicaragua	Managua	129494	6465513	NA	.ni	NIO	Cordoba	505	###-###-#	^(\d{7})$	es-NI,en	3617476	CR,HN	
+NL	NLD	528	NL	Netherlands	Amsterdam	41526	17231017	EU	.nl	EUR	Euro	31	#### @@	^(\d{4}\s?[a-zA-Z]{2})$	nl-NL,fy-NL	2750405	DE,BE	
+NO	NOR	578	NO	Norway	Oslo	324220	5314336	EU	.no	NOK	Krone	47	####	^(\d{4})$	no,nb,nn,se,fi	3144096	FI,RU,SE	
+NP	NPL	524	NP	Nepal	Kathmandu	140800	28087871	AS	.np	NPR	Rupee	977	#####	^(\d{5})$	ne,en	1282988	CN,IN	
+NR	NRU	520	NR	Nauru	Yaren	21	12704	OC	.nr	AUD	Dollar	674			na,en-NR	2110425		
 NU	NIU	570	NE	Niue	Alofi	260	2166	OC	.nu	NZD	Dollar	683			niu,en-NU	4036232		
-NZ	NZL	554	NZ	New Zealand	Wellington	268680	4252277	OC	.nz	NZD	Dollar	64	####	^(\d{4})$	en-NZ,mi	2186224		
-OM	OMN	512	MU	Oman	Muscat	212460	2967717	AS	.om	OMR	Rial	968	###	^(\d{3})$	ar-OM,en,bal,ur	286963	SA,YE,AE	
-PA	PAN	591	PM	Panama	Panama City	78200	3410676	NA	.pa	PAB	Balboa	507			es-PA,en	3703430	CR,CO	
-PE	PER	604	PE	Peru	Lima	1285220	29907003	SA	.pe	PEN	Sol	51			es-PE,qu,ay	3932488	EC,CL,BO,BR,CO	
-PF	PYF	258	FP	French Polynesia	Papeete	4167	270485	OC	.pf	XPF	Franc	689	#####	^((97|98)7\d{2})$	fr-PF,ty	4030656		
-PG	PNG	598	PP	Papua New Guinea	Port Moresby	462840	6064515	OC	.pg	PGK	Kina	675	###	^(\d{3})$	en-PG,ho,meu,tpi	2088628	ID	
-PH	PHL	608	RP	Philippines	Manila	300000	99900177	AS	.ph	PHP	Peso	63	####	^(\d{4})$	tl,en-PH,fil	1694008		
-PK	PAK	586	PK	Pakistan	Islamabad	803940	184404791	AS	.pk	PKR	Rupee	92	#####	^(\d{5})$	ur-PK,en-PK,pa,sd,ps,brh	1168579	CN,AF,IR,IN	
-PL	POL	616	PL	Poland	Warsaw	312685	38500000	EU	.pl	PLN	Zloty	48	##-###	^(\d{5})$	pl	798544	DE,LT,SK,CZ,BY,UA,RU	
+NZ	NZL	554	NZ	New Zealand	Wellington	268680	4885500	OC	.nz	NZD	Dollar	64	####	^(\d{4})$	en-NZ,mi	2186224		
+OM	OMN	512	MU	Oman	Muscat	212460	4829483	AS	.om	OMR	Rial	968	###	^(\d{3})$	ar-OM,en,bal,ur	286963	SA,YE,AE	
+PA	PAN	591	PM	Panama	Panama City	78200	4176873	NA	.pa	PAB	Balboa	507			es-PA,en	3703430	CR,CO	
+PE	PER	604	PE	Peru	Lima	1285220	31989256	SA	.pe	PEN	Sol	51	#####	^(\d{5})$	es-PE,qu,ay	3932488	EC,CL,BO,BR,CO	
+PF	PYF	258	FP	French Polynesia	Papeete	4167	277679	OC	.pf	XPF	Franc	689	#####	^((97|98)7\d{2})$	fr-PF,ty	4030656		
+PG	PNG	598	PP	Papua New Guinea	Port Moresby	462840	8606316	OC	.pg	PGK	Kina	675	###	^(\d{3})$	en-PG,ho,meu,tpi	2088628	ID	
+PH	PHL	608	RP	Philippines	Manila	300000	106651922	AS	.ph	PHP	Peso	63	####	^(\d{4})$	tl,en-PH,fil,ceb,ilo,hil,war,pam,bik,bcl,pag,mrw,tsg,mdh,cbk,krj,sgd,msb,akl,ibg,yka,mta,abx	1694008		
+PK	PAK	586	PK	Pakistan	Islamabad	803940	212215030	AS	.pk	PKR	Rupee	92	#####	^(\d{5})$	ur-PK,en-PK,pa,sd,ps,brh	1168579	CN,AF,IR,IN	
+PL	POL	616	PL	Poland	Warsaw	312685	37978548	EU	.pl	PLN	Zloty	48	##-###	^\d{2}-\d{3}$	pl	798544	DE,LT,SK,CZ,BY,UA,RU	
 PM	SPM	666	SB	Saint Pierre and Miquelon	Saint-Pierre	242	7012	NA	.pm	EUR	Euro	508	#####	^(97500)$	fr-PM	3424932		
 PN	PCN	612	PC	Pitcairn	Adamstown	47	46	OC	.pn	NZD	Dollar	870			en-PN	4030699		
-PR	PRI	630	RQ	Puerto Rico	San Juan	9104	3916632	NA	.pr	USD	Dollar	+1-787 and 1-939	#####-####	^(\d{9})$	en-PR,es-PR	4566966		
-PS	PSE	275	WE	Palestinian Territory	East Jerusalem	5970	3800000	AS	.ps	ILS	Shekel	970			ar-PS	6254930	JO,IL,EG	
-PT	PRT	620	PO	Portugal	Lisbon	92391	10676000	EU	.pt	EUR	Euro	351	####-###	^(\d{7})$	pt-PT,mwl	2264397	ES	
-PW	PLW	585	PS	Palau	Melekeok	458	19907	OC	.pw	USD	Dollar	680	96940	^(96940)$	pau,sov,en-PW,tox,ja,fil,zh	1559582		
-PY	PRY	600	PA	Paraguay	Asuncion	406750	6375830	SA	.py	PYG	Guarani	595	####	^(\d{4})$	es-PY,gn	3437598	BO,BR,AR	
-QA	QAT	634	QA	Qatar	Doha	11437	840926	AS	.qa	QAR	Rial	974			ar-QA,es	289688	SA	
+PR	PRI	630	RQ	Puerto Rico	San Juan	9104	3195153	NA	.pr	USD	Dollar	+1-787 and 1-939	#####-####	^00[679]\d{2}(?:-\d{4})?$	en-PR,es-PR	4566966		
+PS	PSE	275	WE	Palestinian Territory	East Jerusalem	5970	4569087	AS	.ps	ILS	Shekel	970			ar-PS	6254930	JO,IL,EG	
+PT	PRT	620	PO	Portugal	Lisbon	92391	10281762	EU	.pt	EUR	Euro	351	####-###	^\d{4}-\d{3}\s?[a-zA-Z]{0,25}$	pt-PT,mwl	2264397	ES	
+PW	PLW	585	PS	Palau	Melekeok	458	17907	OC	.pw	USD	Dollar	680	96940	^(96940)$	pau,sov,en-PW,tox,ja,fil,zh	1559582		
+PY	PRY	600	PA	Paraguay	Asuncion	406750	6956071	SA	.py	PYG	Guarani	595	####	^(\d{4})$	es-PY,gn	3437598	BO,BR,AR	
+QA	QAT	634	QA	Qatar	Doha	11437	2781677	AS	.qa	QAR	Rial	974			ar-QA,es	289688	SA	
 RE	REU	638	RE	Reunion	Saint-Denis	2517	776948	AF	.re	EUR	Euro	262	#####	^((97|98)(4|7|8)\d{2})$	fr-RE	935317		
-RO	ROU	642	RO	Romania	Bucharest	237500	21959278	EU	.ro	RON	Leu	40	######	^(\d{6})$	ro,hu,rom	798549	MD,HU,UA,BG,RS	
-RS	SRB	688	RI	Serbia	Belgrade	88361	7344847	EU	.rs	RSD	Dinar	381	######	^(\d{6})$	sr,hu,bs,rom	6290252	AL,HU,MK,RO,HR,BA,BG,ME,XK	
-RU	RUS	643	RS	Russia	Moscow	17100000	140702000	EU	.ru	RUB	Ruble	7	######	^(\d{6})$	ru,tt,xal,cau,ady,kv,ce,tyv,cv,udm,tut,mns,bua,myv,mdf,chm,ba,inh,tut,kbd,krc,ava,sah,nog	2017370	GE,CN,BY,UA,KZ,LV,PL,EE,LT,FI,MN,NO,AZ,KP	
-RW	RWA	646	RW	Rwanda	Kigali	26338	11055976	AF	.rw	RWF	Franc	250			rw,en-RW,fr-RW,sw	49518	TZ,CD,BI,UG	
-SA	SAU	682	SA	Saudi Arabia	Riyadh	1960582	25731776	AS	.sa	SAR	Rial	966	#####	^(\d{5})$	ar-SA	102358	QA,OM,IQ,YE,JO,AE,KW	
-SB	SLB	090	BP	Solomon Islands	Honiara	28450	559198	OC	.sb	SBD	Dollar	677			en-SB,tpi	2103350		
-SC	SYC	690	SE	Seychelles	Victoria	455	88340	AF	.sc	SCR	Rupee	248			en-SC,fr-SC	241170		
-SD	SDN	729	SU	Sudan	Khartoum	1861484	35000000	AF	.sd	SDG	Pound	249	#####	^(\d{5})$	ar-SD,en,fia	366755	SS,TD,EG,ET,ER,LY,CF	
-SS	SSD	728	OD	South Sudan	Juba	644329	8260490	AF		SSP	Pound	211			en	7909807	CD,CF,ET,KE,SD,UG,	
-SE	SWE	752	SW	Sweden	Stockholm	449964	9555893	EU	.se	SEK	Krona	46	### ##	^(?:SE)*(\d{5})$	sv-SE,se,sma,fi-SE	2661886	NO,FI	
-SG	SGP	702	SN	Singapore	Singapur	692.7	4701069	AS	.sg	SGD	Dollar	65	######	^(\d{6})$	cmn,en-SG,ms-SG,ta-SG,zh-SG	1880251		
+RO	ROU	642	RO	Romania	Bucharest	237500	19473936	EU	.ro	RON	Leu	40	######	^(\d{6})$	ro,hu,rom	798549	MD,HU,UA,BG,RS	
+RS	SRB	688	RI	Serbia	Belgrade	88361	6982084	EU	.rs	RSD	Dinar	381	######	^(\d{6})$	sr,hu,bs,rom	6290252	AL,HU,MK,RO,HR,BA,BG,ME,XK	
+RU	RUS	643	RS	Russia	Moscow	17100000	144478050	EU	.ru	RUB	Ruble	7	######	^(\d{6})$	ru,tt,xal,cau,ady,kv,ce,tyv,cv,udm,tut,mns,bua,myv,mdf,chm,ba,inh,kbd,krc,av,sah,nog	2017370	GE,CN,BY,UA,KZ,LV,PL,EE,LT,FI,MN,NO,AZ,KP	
+RW	RWA	646	RW	Rwanda	Kigali	26338	12301939	AF	.rw	RWF	Franc	250			rw,en-RW,fr-RW,sw	49518	TZ,CD,BI,UG	
+SA	SAU	682	SA	Saudi Arabia	Riyadh	1960582	33699947	AS	.sa	SAR	Rial	966	#####	^(\d{5})$	ar-SA	102358	QA,OM,IQ,YE,JO,AE,KW	
+SB	SLB	090	BP	Solomon Islands	Honiara	28450	652858	OC	.sb	SBD	Dollar	677			en-SB,tpi	2103350		
+SC	SYC	690	SE	Seychelles	Victoria	455	96762	AF	.sc	SCR	Rupee	248			en-SC,fr-SC	241170		
+SD	SDN	729	SU	Sudan	Khartoum	1861484	41801533	AF	.sd	SDG	Pound	249	#####	^(\d{5})$	ar-SD,en,fia	366755	SS,TD,EG,ET,ER,LY,CF	
+SS	SSD	728	OD	South Sudan	Juba	644329	8260490	AF	.ss	SSP	Pound	211			en	7909807	CD,CF,ET,KE,SD,UG	
+SE	SWE	752	SW	Sweden	Stockholm	449964	10183175	EU	.se	SEK	Krona	46	### ##	^(?:SE)?\d{3}\s\d{2}$	sv-SE,se,sma,fi-SE	2661886	NO,FI	
+SG	SGP	702	SN	Singapore	Singapore	692.7	5638676	AS	.sg	SGD	Dollar	65	######	^(\d{6})$	cmn,en-SG,ms-SG,ta-SG,zh-SG	1880251		
 SH	SHN	654	SH	Saint Helena	Jamestown	410	7460	AF	.sh	SHP	Pound	290	STHL 1ZZ	^(STHL1ZZ)$	en-SH	3370751		
-SI	SVN	705	SI	Slovenia	Ljubljana	20273	2007000	EU	.si	EUR	Euro	386	####	^(?:SI)*(\d{4})$	sl,sh	3190538	HU,IT,HR,AT	
-SJ	SJM	744	SV	Svalbard and Jan Mayen	Longyearbyen	62049	2550	EU	.sj	NOK	Krone	47			no,ru	607072		
-SK	SVK	703	LO	Slovakia	Bratislava	48845	5455000	EU	.sk	EUR	Euro	421	### ##	^(\d{5})$	sk,hu	3057568	PL,HU,CZ,UA,AT	
-SL	SLE	694	SL	Sierra Leone	Freetown	71740	5245695	AF	.sl	SLL	Leone	232			en-SL,men,tem	2403846	LR,GN	
-SM	SMR	674	SM	San Marino	San Marino	61.2	31477	EU	.sm	EUR	Euro	378	4789#	^(4789\d)$	it-SM	3168068	IT	
-SN	SEN	686	SG	Senegal	Dakar	196190	12323252	AF	.sn	XOF	Franc	221	#####	^(\d{5})$	fr-SN,wo,fuc,mnk	2245662	GN,MR,GW,GM,ML	
-SO	SOM	706	SO	Somalia	Mogadishu	637657	10112453	AF	.so	SOS	Shilling	252	@@  #####	^([A-Z]{2}\d{5})$	so-SO,ar-SO,it,en-SO	51537	ET,KE,DJ	
-SR	SUR	740	NS	Suriname	Paramaribo	163270	492829	SA	.sr	SRD	Dollar	597			nl-SR,en,srn,hns,jv	3382998	GY,BR,GF	
-ST	STP	678	TP	Sao Tome and Principe	Sao Tome	1001	175808	AF	.st	STD	Dobra	239			pt-ST	2410758		
-SV	SLV	222	ES	El Salvador	San Salvador	21040	6052064	NA	.sv	USD	Dollar	503	CP ####	^(?:CP)*(\d{4})$	es-SV	3585968	GT,HN	
-SX	SXM	534	NN	Sint Maarten	Philipsburg		37429	NA	.sx	ANG	Guilder	599			nl,en	7609695	MF	
-SY	SYR	760	SY	Syria	Damascus	185180	22198110	AS	.sy	SYP	Pound	963			ar-SY,ku,hy,arc,fr,en	163843	IQ,JO,IL,TR,LB	
-SZ	SWZ	748	WZ	Swaziland	Mbabane	17363	1354051	AF	.sz	SZL	Lilangeni	268	@###	^([A-Z]\d{3})$	en-SZ,ss-SZ	934841	ZA,MZ	
-TC	TCA	796	TK	Turks and Caicos Islands	Cockburn Town	430	20556	NA	.tc	USD	Dollar	+1-649	TKCA 1ZZ	^(TKCA 1ZZ)$	en-TC	3576916		
-TD	TCD	148	CD	Chad	N'Djamena	1284000	10543464	AF	.td	XAF	Franc	235			fr-TD,ar-TD,sre	2434508	NE,LY,CF,SD,CM,NG	
-TF	ATF	260	FS	French Southern Territories	Port-aux-Francais	7829	140	AN	.tf	EUR	Euro  				fr	1546748		
-TG	TGO	768	TO	Togo	Lome	56785	6587239	AF	.tg	XOF	Franc	228			fr-TG,ee,hna,kbp,dag,ha	2363686	BJ,GH,BF	
-TH	THA	764	TH	Thailand	Bangkok	514000	67089500	AS	.th	THB	Baht	66	#####	^(\d{5})$	th,en	1605651	LA,MM,KH,MY	
-TJ	TJK	762	TI	Tajikistan	Dushanbe	143100	7487489	AS	.tj	TJS	Somoni	992	######	^(\d{6})$	tg,ru	1220409	CN,AF,KG,UZ	
+SI	SVN	705	SI	Slovenia	Ljubljana	20273	2067372	EU	.si	EUR	Euro	386	####	^(?:SI)*(\d{4})$	sl,sh	3190538	HU,IT,HR,AT	
+SJ	SJM	744	SV	Svalbard and Jan Mayen	Longyearbyen	62049	2550	EU	.sj	NOK	Krone	47	####	^(\d{4})$	no,ru	607072		
+SK	SVK	703	LO	Slovakia	Bratislava	48845	5447011	EU	.sk	EUR	Euro	421	### ##	^\d{3}\s?\d{2}$	sk,hu	3057568	PL,HU,CZ,UA,AT	
+SL	SLE	694	SL	Sierra Leone	Freetown	71740	7650154	AF	.sl	SLL	Leone	232			en-SL,men,tem	2403846	LR,GN	
+SM	SMR	674	SM	San Marino	San Marino	61.2	33785	EU	.sm	EUR	Euro	378	4789#	^(4789\d)$	it-SM	3168068	IT	
+SN	SEN	686	SG	Senegal	Dakar	196190	15854360	AF	.sn	XOF	Franc	221	#####	^(\d{5})$	fr-SN,wo,fuc,mnk	2245662	GN,MR,GW,GM,ML	
+SO	SOM	706	SO	Somalia	Mogadishu	637657	15008154	AF	.so	SOS	Shilling	252	@@  #####	^([A-Z]{2}\d{5})$	so-SO,ar-SO,it,en-SO	51537	ET,KE,DJ	
+SR	SUR	740	NS	Suriname	Paramaribo	163270	575991	SA	.sr	SRD	Dollar	597			nl-SR,en,srn,hns,jv	3382998	GY,BR,GF	
+ST	STP	678	TP	Sao Tome and Principe	Sao Tome	1001	197700	AF	.st	STN	Dobra	239			pt-ST	2410758		
+SV	SLV	222	ES	El Salvador	San Salvador	21040	6420744	NA	.sv	USD	Dollar	503	CP ####	^(?:CP)*(\d{4})$	es-SV	3585968	GT,HN	
+SX	SXM	534	NN	Sint Maarten	Philipsburg	21	40654	NA	.sx	ANG	Guilder	599			nl,en	7609695	MF	
+SY	SYR	760	SY	Syria	Damascus	185180	16906283	AS	.sy	SYP	Pound	963			ar-SY,ku,hy,arc,fr,en	163843	IQ,JO,IL,TR,LB	
+SZ	SWZ	748	WZ	Eswatini	Mbabane	17363	1136191	AF	.sz	SZL	Lilangeni	268	@###	^([A-Z]\d{3})$	en-SZ,ss-SZ	934841	ZA,MZ	
+TC	TCA	796	TK	Turks and Caicos Islands	Cockburn Town	430	37665	NA	.tc	USD	Dollar	+1-649	TKCA 1ZZ	^(TKCA 1ZZ)$	en-TC	3576916		
+TD	TCD	148	CD	Chad	N'Djamena	1284000	15477751	AF	.td	XAF	Franc	235			fr-TD,ar-TD,sre	2434508	NE,LY,CF,SD,CM,NG	
+TF	ATF	260	FS	French Southern Territories	Port-aux-Francais	7829	140	AN	.tf	EUR	Euro				fr	1546748		
+TG	TGO	768	TO	Togo	Lome	56785	7889094	AF	.tg	XOF	Franc	228			fr-TG,ee,hna,kbp,dag,ha	2363686	BJ,GH,BF	
+TH	THA	764	TH	Thailand	Bangkok	514000	69428524	AS	.th	THB	Baht	66	#####	^(\d{5})$	th,en	1605651	LA,MM,KH,MY	
+TJ	TJK	762	TI	Tajikistan	Dushanbe	143100	9100837	AS	.tj	TJS	Somoni	992	######	^(\d{6})$	tg,ru	1220409	CN,AF,KG,UZ	
 TK	TKL	772	TL	Tokelau		10	1466	OC	.tk	NZD	Dollar	690			tkl,en-TK	4031074		
-TL	TLS	626	TT	East Timor	Dili	15007	1154625	OC	.tl	USD	Dollar	670			tet,pt-TL,id,en	1966436	ID	
-TM	TKM	795	TX	Turkmenistan	Ashgabat	488100	4940916	AS	.tm	TMT	Manat	993	######	^(\d{6})$	tk,ru,uz	1218197	AF,IR,UZ,KZ	
-TN	TUN	788	TS	Tunisia	Tunis	163610	10589025	AF	.tn	TND	Dinar	216	####	^(\d{4})$	ar-TN,fr	2464461	DZ,LY	
-TO	TON	776	TN	Tonga	Nuku'alofa	748	122580	OC	.to	TOP	Pa'anga	676			to,en-TO	4032283		
-TR	TUR	792	TU	Turkey	Ankara	780580	77804122	AS	.tr	TRY	Lira	90	#####	^(\d{5})$	tr-TR,ku,diq,az,av	298795	SY,GE,IQ,IR,GR,AM,AZ,BG	
-TT	TTO	780	TD	Trinidad and Tobago	Port of Spain	5128	1228691	NA	.tt	TTD	Dollar	+1-868			en-TT,hns,fr,es,zh	3573591		
-TV	TUV	798	TV	Tuvalu	Funafuti	26	10472	OC	.tv	AUD	Dollar	688			tvl,en,sm,gil	2110297		
-TW	TWN	158	TW	Taiwan	Taipei	35980	22894384	AS	.tw	TWD	Dollar	886	#####	^(\d{5})$	zh-TW,zh,nan,hak	1668284		
-TZ	TZA	834	TZ	Tanzania	Dodoma	945087	41892895	AF	.tz	TZS	Shilling	255			sw-TZ,en,ar	149590	MZ,KE,CD,RW,ZM,BI,UG,MW	
-UA	UKR	804	UP	Ukraine	Kiev	603700	45415596	EU	.ua	UAH	Hryvnia	380	#####	^(\d{5})$	uk,ru-UA,rom,pl,hu	690791	PL,MD,HU,SK,BY,RO,RU	
-UG	UGA	800	UG	Uganda	Kampala	236040	33398682	AF	.ug	UGX	Shilling	256			en-UG,lg,sw,ar	226074	TZ,KE,SS,CD,RW	
-UM	UMI	581		United States Minor Outlying Islands		0	0	OC	.um	USD	Dollar 	1			en-UM	5854968		
-US	USA	840	US	United States	Washington	9629091	310232863	NA	.us	USD	Dollar	1	#####-####	^\d{5}(-\d{4})?$	en-US,es-US,haw,fr	6252001	CA,MX,CU	
-UY	URY	858	UY	Uruguay	Montevideo	176220	3477000	SA	.uy	UYU	Peso	598	#####	^(\d{5})$	es-UY	3439705	BR,AR	
-UZ	UZB	860	UZ	Uzbekistan	Tashkent	447400	27865738	AS	.uz	UZS	Som	998	######	^(\d{6})$	uz,ru,tg	1512440	TM,AF,KG,TJ,KZ	
+TL	TLS	626	TT	Timor Leste	Dili	15007	1267972	OC	.tl	USD	Dollar	670			tet,pt-TL,id,en	1966436	ID	
+TM	TKM	795	TX	Turkmenistan	Ashgabat	488100	5850908	AS	.tm	TMT	Manat	993	######	^(\d{6})$	tk,ru,uz	1218197	AF,IR,UZ,KZ	
+TN	TUN	788	TS	Tunisia	Tunis	163610	11565204	AF	.tn	TND	Dinar	216	####	^(\d{4})$	ar-TN,fr	2464461	DZ,LY	
+TO	TON	776	TN	Tonga	Nuku'alofa	748	103197	OC	.to	TOP	Pa'anga	676			to,en-TO	4032283		
+TR	TUR	792	TU	Turkey	Ankara	780580	82319724	AS	.tr	TRY	Lira	90	#####	^(\d{5})$	tr-TR,ku,diq,az,av	298795	SY,GE,IQ,IR,GR,AM,AZ,BG	
+TT	TTO	780	TD	Trinidad and Tobago	Port of Spain	5128	1389858	NA	.tt	TTD	Dollar	+1-868			en-TT,hns,fr,es,zh	3573591		
+TV	TUV	798	TV	Tuvalu	Funafuti	26	11508	OC	.tv	AUD	Dollar	688			tvl,en,sm,gil	2110297		
+TW	TWN	158	TW	Taiwan	Taipei	35980	23451837	AS	.tw	TWD	Dollar	886	#####	^(\d{5})$	zh-TW,zh,nan,hak	1668284		
+TZ	TZA	834	TZ	Tanzania	Dodoma	945087	56318348	AF	.tz	TZS	Shilling	255			sw-TZ,en,ar	149590	MZ,KE,CD,RW,ZM,BI,UG,MW	
+UA	UKR	804	UP	Ukraine	Kyiv	603700	44622516	EU	.ua	UAH	Hryvnia	380	#####	^(\d{5})$	uk,ru-UA,rom,pl,hu	690791	PL,MD,HU,SK,BY,RO,RU	
+UG	UGA	800	UG	Uganda	Kampala	236040	42723139	AF	.ug	UGX	Shilling	256			en-UG,lg,sw,ar	226074	TZ,KE,SS,CD,RW	
+UM	UMI	581		United States Minor Outlying Islands		0	0	OC	.um	USD	Dollar	1			en-UM	5854968		
+US	USA	840	US	United States	Washington	9629091	327167434	NA	.us	USD	Dollar	1	#####-####	^\d{5}(-\d{4})?$	en-US,es-US,haw,fr	6252001	CA,MX,CU	
+UY	URY	858	UY	Uruguay	Montevideo	176220	3449299	SA	.uy	UYU	Peso	598	#####	^(\d{5})$	es-UY	3439705	BR,AR	
+UZ	UZB	860	UZ	Uzbekistan	Tashkent	447400	32955400	AS	.uz	UZS	Som	998	######	^(\d{6})$	uz,ru,tg	1512440	TM,AF,KG,TJ,KZ	
 VA	VAT	336	VT	Vatican	Vatican City	0.44	921	EU	.va	EUR	Euro	379	#####	^(\d{5})$	la,it,fr	3164670	IT	
-VC	VCT	670	VC	Saint Vincent and the Grenadines	Kingstown	389	104217	NA	.vc	XCD	Dollar	+1-784			en-VC,fr	3577815		
-VE	VEN	862	VE	Venezuela	Caracas	912050	27223228	SA	.ve	VEF	Bolivar	58	####	^(\d{4})$	es-VE	3625428	GY,BR,CO	
-VG	VGB	092	VI	British Virgin Islands	Road Town	153	21730	NA	.vg	USD	Dollar	+1-284			en-VG	3577718		
-VI	VIR	850	VQ	U.S. Virgin Islands	Charlotte Amalie	352	108708	NA	.vi	USD	Dollar	+1-340	#####-####	^\d{5}(-\d{4})?$	en-VI	4796775		
-VN	VNM	704	VM	Vietnam	Hanoi	329560	89571130	AS	.vn	VND	Dong	84	######	^(\d{6})$	vi,en,fr,zh,km	1562822	CN,LA,KH	
-VU	VUT	548	NH	Vanuatu	Port Vila	12200	221552	OC	.vu	VUV	Vatu	678			bi,en-VU,fr-VU	2134431		
+VC	VCT	670	VC	Saint Vincent and the Grenadines	Kingstown	389	110211	NA	.vc	XCD	Dollar	+1-784			en-VC,fr	3577815		
+VE	VEN	862	VE	Venezuela	Caracas	912050	28870195	SA	.ve	VES	Bolivar Soberano	58	####	^(\d{4})$	es-VE	3625428	GY,BR,CO	
+VG	VGB	092	VI	British Virgin Islands	Road Town	153	29802	NA	.vg	USD	Dollar	+1-284			en-VG	3577718		
+VI	VIR	850	VQ	U.S. Virgin Islands	Charlotte Amalie	352	106977	NA	.vi	USD	Dollar	+1-340	#####-####	^008\d{2}(?:-\d{4})?$	en-VI	4796775		
+VN	VNM	704	VM	Vietnam	Hanoi	329560	95540395	AS	.vn	VND	Dong	84	######	^(\d{6})$	vi,en,fr,zh,km	1562822	CN,LA,KH	
+VU	VUT	548	NH	Vanuatu	Port Vila	12200	292680	OC	.vu	VUV	Vatu	678			bi,en-VU,fr-VU	2134431		
 WF	WLF	876	WF	Wallis and Futuna	Mata Utu	274	16025	OC	.wf	XPF	Franc	681	#####	^(986\d{2})$	wls,fud,fr-WF	4034749		
-WS	WSM	882	WS	Samoa	Apia	2944	192001	OC	.ws	WST	Tala	685			sm,en-WS	4034894		
-YE	YEM	887	YM	Yemen	Sanaa	527970	23495361	AS	.ye	YER	Rial	967			ar-YE	69543	SA,OM	
-YT	MYT	175	MF	Mayotte	Mamoudzou	374	159042	AF	.yt	EUR	Euro	262	#####	^(\d{5})$	fr-YT	1024031		
-ZA	ZAF	710	SF	South Africa	Pretoria	1219912	49000000	AF	.za	ZAR	Rand	27	####	^(\d{4})$	zu,xh,af,nso,en-ZA,tn,st,ts,ss,ve,nr	953987	ZW,SZ,MZ,BW,NA,LS	
-ZM	ZMB	894	ZA	Zambia	Lusaka	752614	13460305	AF	.zm	ZMW	Kwacha	260	#####	^(\d{5})$	en-ZM,bem,loz,lun,lue,ny,toi	895949	ZW,TZ,MZ,CD,NA,MW,AO	
-ZW	ZWE	716	ZI	Zimbabwe	Harare	390580	11651858	AF	.zw	ZWL	Dollar	263			en-ZW,sn,nr,nd	878675	ZA,MZ,BW,ZM	
-CS	SCG	891	YI	Serbia and Montenegro	Belgrade	102350	10829175	EU	.cs	RSD	Dinar	381	#####	^(\d{5})$	cu,hu,sq,sr		AL,HU,MK,RO,HR,BA,BG	
-AN	ANT	530	NT	Netherlands Antilles	Willemstad	960	136197	NA	.an	ANG	Guilder	599			nl-AN,en,es		GP	
+WS	WSM	882	WS	Samoa	Apia	2944	196130	OC	.ws	WST	Tala	685			sm,en-WS	4034894		
+YE	YEM	887	YM	Yemen	Sanaa	527970	28498687	AS	.ye	YER	Rial	967			ar-YE	69543	SA,OM	
+YT	MYT	175	MF	Mayotte	Mamoudzou	374	279471	AF	.yt	EUR	Euro	262	#####	^(\d{5})$	fr-YT	1024031		
+ZA	ZAF	710	SF	South Africa	Pretoria	1219912	57779622	AF	.za	ZAR	Rand	27	####	^(\d{4})$	zu,xh,af,nso,en-ZA,tn,st,ts,ss,ve,nr	953987	ZW,SZ,MZ,BW,NA,LS	
+ZM	ZMB	894	ZA	Zambia	Lusaka	752614	17351822	AF	.zm	ZMW	Kwacha	260	#####	^(\d{5})$	en-ZM,bem,loz,lun,lue,ny,toi	895949	ZW,TZ,MZ,CD,NA,MW,AO	
+ZW	ZWE	716	ZI	Zimbabwe	Harare	390580	14439018	AF	.zw	ZWL	Dollar	263			en-ZW,sn,nr,nd	878675	ZA,MZ,BW,ZM	
+CS	SCG	891	YI	Serbia and Montenegro	Belgrade	102350	10829175	EU	.cs	RSD	Dinar	381	#####	^(\d{5})$	cu,hu,sq,sr	8505033	AL,HU,MK,RO,HR,BA,BG	
+AN	ANT	530	NT	Netherlands Antilles	Willemstad	960	300000	NA	.an	ANG	Guilder	599			nl-AN,en,es	8505032	GP	


### PR DESCRIPTION
I'm not sure if this repo is still active but just in case it is here is an import of the latest geonames.org data.
We had issues in the Solus installer for cases like selecting Kyiv, which were solved by an updated dataset.